### PR TITLE
add & generate licenses

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,28 @@
+Copyright 2015 Goran Gajic
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---
+
+Icons are taken from the other projects
+so please check each project licences accordingly.
+
+Font Awesome by Dave Gandy - http://fontawesome.io
+License: SIL OFL 1.1 http://scripts.sil.org/OFL
+
+Material Design icons by Google http://google.github.io/material-design-icons/
+License: CC-BY 4.0 https://github.com/google/material-design-icons/blob/master/LICENSE
+
+336 pixel perfect, all-purpose vector icons in a web-font kit http://typicons.com by Stephen Hutchings <http://www.s-ings.com/>
+License: CC BY-SA http://creativecommons.org/licenses/by-sa/3.0/
+
+Github Octicons icons by Github https://octicons.github.com/
+License: SIL OFL 1.1 https://github.com/github/octicons/blob/master/LICENSE.txt
+
+The premium icon font for Ionic Framework.
+License: MIT https://github.com/driftyco/ionicons/blob/master/LICENSE
+

--- a/bin/generate-docs.js
+++ b/bin/generate-docs.js
@@ -10,6 +10,9 @@ import icons from '../icons/info';
 // because stateless function components
 global.React = React;
 
+
+// generate documents
+
 var indexFile = path.join(__dirname, '..', 'docs', 'sample.html');
 var indexHtml = fs.readFileSync(indexFile, 'utf-8');
 
@@ -17,6 +20,11 @@ function writeFile(pageName, content) {
     var page = indexHtml.replace("{{#content}}", content);
     var destFile = path.join(__dirname, '..', 'publish', pageName + '.html');
     fs.writeFileSync(destFile, page, 'utf-8')
+}
+
+var publishDir = path.join(__dirname, '..', 'publish');
+if (!fs.existsSync(publishDir)) {
+    fs.mkdirSync(publishDir);
 }
 
 Object.keys(icons).forEach(function(key, index) {
@@ -39,3 +47,19 @@ readme = renderToStaticMarkup(<App active="index" icons={icons}>
                     </App>);
 
 writeFile('index', readme);
+
+
+// generate license file
+
+var licenseHeaerFile = path.join(__dirname, '..', 'docs', 'license-header');
+var licenseOutFile = path.join(__dirname, '..', 'LICENSE');
+var licenseHeader = fs.readFileSync(licenseHeaerFile, 'utf-8');
+
+var licenses = '';
+Object.keys(icons).forEach(function(key, index) {
+    var icon = icons[key];
+    licenses += `${icon.attribution}\n`;
+    licenses += `License: ${icon.license} ${icon.licenseUrl}\n\n`;
+});
+
+fs.writeFileSync(licenseOutFile, licenseHeader + licenses, 'utf-8');

--- a/docs/license-header
+++ b/docs/license-header
@@ -1,0 +1,13 @@
+Copyright 2015 Goran Gajic
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---
+
+Icons are taken from the other projects
+so please check each project licences accordingly.
+

--- a/icons/info.js
+++ b/icons/info.js
@@ -3,35 +3,35 @@ module.exports = {
         name: "Font Awesome",
         url: "http://fontawesome.io/",
         attribution: "Font Awesome by Dave Gandy - http://fontawesome.io",
-        licence: "SIL OFL 1.1",
-        licenceUrl: "http://scripts.sil.org/OFL"
+        license: "SIL OFL 1.1",
+        licenseUrl: "http://scripts.sil.org/OFL"
     },
     md: {
         name: "Material",
         url: "https://www.google.com/design/icons/",
         attribution: "Material Design icons by Google http://google.github.io/material-design-icons/",
-        licence: "CC-BY 4.0",
-        licenceUrl: "https://github.com/google/material-design-icons/blob/master/LICENSE"
+        license: "CC-BY 4.0",
+        licenseUrl: "https://github.com/google/material-design-icons/blob/master/LICENSE"
     },
     ti: {
         name: "Typicons",
         url: "http://typicons.com/",
         attribution: "336 pixel perfect, all-purpose vector icons in a web-font kit http://typicons.com by Stephen Hutchings <http://www.s-ings.com/>",
-        licence: "CC BY-SA",
-        licenceUrl: "http://creativecommons.org/licenses/by-sa/3.0/"
+        license: "CC BY-SA",
+        licenseUrl: "http://creativecommons.org/licenses/by-sa/3.0/"
     },
     go: {
         name: "Github Octicons",
         url: "https://octicons.github.com/",
         attribution: "Github Octicons icons by Github https://octicons.github.com/",
-        licence: "SIL OFL 1.1",
-        licenceUrl: "https://github.com/github/octicons/blob/master/LICENSE.txt"
+        license: "SIL OFL 1.1",
+        licenseUrl: "https://github.com/github/octicons/blob/master/LICENSE.txt"
     },
     io: {
         name: "Ionicons",
         url: "http://ionicons.com/",
         attribution: "The premium icon font for Ionic Framework.",
-        licence: "MIT",
-        licenceUrl: "https://github.com/driftyco/ionicons/blob/master/LICENSE",
+        license: "MIT",
+        licenseUrl: "https://github.com/driftyco/ionicons/blob/master/LICENSE",
     }
 }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,8 @@
     "gulp": "^3.9.0",
     "marky-markdown": "^12.0.0",
     "material-design-lite": "^1.0.6",
+    "react": "^16.3.1",
+    "react-dom": "^16.3.1",
     "svg-scaler": "gorangajic/svg-scaler#take-size-viewbox",
     "underscore": "^1.8.3",
     "validate-commit-msg": "^2.6.1"


### PR DESCRIPTION
required for exporting the license of dependent package.
for example `yarn licenses generate-disclaimer`.

- add need packages
- license file generate from info.js
