### PR TITLE
Please fix correct path in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ class Question extends React.Component {
 or import multiple icons from the same pack
 
 ```jsx
-import {MdCancel, MdChat, MdCheck} from 'react-icons/md';
+import {MdCancel, MdChat, MdCheck} from 'react-icons/lib/md';
 ```
 
 Each icon pack is in its own folder:


### PR DESCRIPTION
At first, I cannot load md icons because the path is incorrect.
Please fix the path.