### PR TITLE
Replace github pages url

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Each icon pack is in its own folder:
 * Github Octicons => `./go`
 * Ionicons => `./io`
 
-To view them all, visit the [docs](http://gorangajic.github.io/react-icons/)
+To view them all, visit the [docs](http://react-icons.github.io/react-icons/)
 
 Also, to view and search for the necessary icons you can use [Icon Viewer](https://andy-pro.github.io/icon-viewer).
 


### PR DESCRIPTION
README.md has old page link.
We can not access to http://gorangajic.github.io/react-icons/ , so I think we should replace the url as http://react-icons.github.io/react-icons/)


```
$ wget -S --spider http://gorangajic.github.io/react-icons/
Spider mode enabled. Check if remote file exists.
--2018-06-15 16:36:40--  http://gorangajic.github.io/react-icons/
Resolving gorangajic.github.io... 185.199.108.153, 185.199.109.153, 185.199.110.153, ...
Connecting to gorangajic.github.io|185.199.108.153|:80... connected.
HTTP request sent, awaiting response... 
  HTTP/1.1 404 Not Found
  Server: GitHub.com
  Content-Type: text/html; charset=utf-8
  ETag: "59429d6e-239c"
  Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'; img-src data:; connect-src 'self'
  X-GitHub-Request-Id: EE78:7F3B:40CD85:46C7C7:5B236C88
  Content-Length: 9116
  Accept-Ranges: bytes
  Date: Fri, 15 Jun 2018 07:36:40 GMT
  Via: 1.1 varnish
  Age: 0
  Connection: keep-alive
  X-Served-By: cache-itm18828-ITM
  X-Cache: MISS
  X-Cache-Hits: 0
  X-Timer: S1529048201.803641,VS0,VE136
  Vary: Accept-Encoding
  X-Fastly-Request-ID: 9b469fdd6992bb89729ba1415cbde360f3a77c96
Remote file does not exist -- broken link!!!
```