### PR TITLE
fa-times icon added to fa directory

### DIFF
--- a/fa/times.js
+++ b/fa/times.js
@@ -1,0 +1,11 @@
+
+import React from 'react'
+import Icon from 'react-icon-base'
+
+const FaTimes = props => (
+    <Icon viewBox="0 0 40 40" {...props}>
+        <g><path d="M1490 1322q0 40-28 68l-136 136q-28 28-68 28t-68-28l-294-294-294 294q-28 28-68 28t-68-28l-136-136q-28-28-28-68t28-68l294-294-294-294q-28-28-28-68t28-68l136-136q28-28 68-28t68 28l294 294 294-294q28-28 68-28t68 28l136 136q28 28 28 68t-28 68l-294 294 294 294q28 28 28 68z"/></g>
+    </Icon>
+);
+
+export default FaTimes;


### PR DESCRIPTION
`fa-times` is a commonly used icon, mainly for the `close`/ `exit` funcionality.
![screenshot from 2018-06-20 10-57-11](https://user-images.githubusercontent.com/16524839/41646010-598af5ba-747b-11e8-9e85-7bd7a4e5e8e0.png)

Icon page on font-awesome website: [https://fontawesome.com/icons/times?style=solid](url)