### PR TITLE
Fix import in first README example for v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm install react-icons --save
 ## Usage
 
 ```jsx
-import { FaBeer } from 'react-icons/lib/fa';
+import { FaBeer } from 'react-icons/fa';
 
 class Question extends React.Component {
     render() {

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ import { IconContext } from "react-icons";
   <div>
     <FaFolder />
   </div>
-<IconContext.Provider>
+</IconContext.Provider>
 ```
 
 key|default|memo


### PR DESCRIPTION
Just updating Dependabot from v2 to v3 and was confused by the import in this example. Further down the README, in the migrating section, there's an example with the correct syntax, so I realised this one is a typo.

Thanks for `react-icons`!