### PR TITLE
Add link to bundle size issue in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ class Question extends React.Component {
 }
 ```
 
+Ending up with a large JS bundle? Check out [this issue](https://github.com/react-icons/react-icons/issues/154).
+
 ### Adjustment CSS
 
 From version 3, `vertical-align: middle` is not automatically given.


### PR DESCRIPTION
Since this project requires a specific Webpack configuration prioritizing `.mjs` files, and that configuration is not (yet) standard across most, large bundle size will be a common issue encountered for newcomers. Therefore, it may be nice to link to this issue in the README where the ES6 imports are recommended.

This PR adds a change to the README pointing users to that issue, in the section where the old format and new format are compared.

Related to https://github.com/react-icons/react-icons/issues/154