### PR TITLE
Prefer es5 syntax in generated source for uglify-js@2 compat

### DIFF
--- a/packages/react-icons/scripts/build.js
+++ b/packages/react-icons/scripts/build.js
@@ -114,7 +114,7 @@ async function dirInit() {
 
     await write(
       [icon.id, "index.js"],
-      "// THIS FILE IS AUTO GENERATED\nconst { GenIcon } = require('../lib/iconBase')\n"
+      "// THIS FILE IS AUTO GENERATED\nvar GenIcon = require('../lib/iconBase').GenIcon\n"
     );
     await write(
       [icon.id, "index.mjs"],


### PR DESCRIPTION
This module will not minify under uglify-js/uglify-es 2. Using a build system that is 2 years old will run into this problem. Obviously people should update their build systems but there isn't a downside to fixing this.

Here is a reduced testcase: https://gist.github.com/austinpray/9de1aa25b64658d981ad218abd61d1f7

fixes https://github.com/react-icons/react-icons/issues/186

Since this is generated source that nobody should be editing there is no downside to just using es5 here for compatibility reasons.