### PR TITLE
Fixed undefined showing up in className.

### DIFF
--- a/packages/react-icons/src/iconBase.tsx
+++ b/packages/react-icons/src/iconBase.tsx
@@ -32,7 +32,7 @@ export function IconBase(props:IconBaseProps & { attr: {} | undefined }): JSX.El
     const computedSize = props.size || conf.size || "1em";
     let className;
     if (conf.className) className = conf.className;
-    if (props.className) className = (className + ' ' || '') + props.className;
+    if (props.className) className = (className ? className + ' ' : '') + props.className;
     const {attr, ...svgProps} = props;
 
     return (


### PR DESCRIPTION
- Added ternary to line 35 of `iconBase.tsx` to account for an `undefined` className
Fixes #189 