### PR TITLE
fix(iconBase): added xmlns to support renderToString

### DIFF
--- a/packages/react-icons/src/iconBase.tsx
+++ b/packages/react-icons/src/iconBase.tsx
@@ -47,6 +47,7 @@ export function IconBase(props:IconBaseProps & { attr: {} | undefined }): JSX.El
         style={{ color: props.color || conf.color, ...conf.style, ...props.style}}
         height={computedSize}
         width={computedSize}
+        xmlns="http://www.w3.org/2000/svg"
       >
       {props.children}
     </svg>


### PR DESCRIPTION
https://github.com/react-icons/react-icons/issues/224

Adds default `xmlns` value to all svgs - can still be overridden though as needed. See Issue for details on why.