### PR TITLE
Adds react to the peer dependencies

### DIFF
--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -18,6 +18,9 @@
     "url": "https://github.com/react-icons/react-icons/issues"
   },
   "homepage": "https://github.com/react-icons/react-icons#readme",
+  "peerDependencies": {
+    "react": "*"
+  },
   "devDependencies": {
     "@babel/cli": "^7.4.4",
     "@babel/core": "^7.4.4",


### PR DESCRIPTION
The `react-icons` package requires `react` (in `iconBase.tsx`) but doesn't list it in its peer dependencies.

This diff fixes it by adding the missing dependency.