### PR TITLE
Add support for stroke-based icons

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,3 +5,7 @@
 packages/react-icons/lib/*
 packages/react-icons/src/icons/*
 !packages/react-icons/src/icons/index.js
+
+# Ignore generated files
+packages/react-icons/??
+packages/react-icons/*.js

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,17 +4,24 @@
     "standard",
     "prettier",
     "prettier/react",
-    "prettier/standard"
+    "prettier/standard",
+    "plugin:react/recommended"
   ],
   "env": {
     "jest": true,
     "browser": true
   },
   "plugins": [
-    "prettier"
+    "prettier",
+    "react"
   ],
   "rules": {
     "prettier/prettier": "error",
-    "no-unused-vars":"warn"
+    "no-unused-vars": "warn"
+  },
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
   }
 }

--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,6 @@
 [submodule "RemixIcon"]
 	path = packages/react-icons/src/icons/RemixIcon
 	url = https://github.com/Remix-Design/RemixIcon.git
+[submodule "px-icon-set"]
+	path = packages/react-icons/src/icons/px-icon-set
+	url = https://github.com/tromgy/px-icon-set.git

--- a/README.md
+++ b/README.md
@@ -39,20 +39,21 @@ For example, to use an icon from **Material Design**, your import would be: `imp
 
 ## Icons
 
-| Icon Library                                                  | License                                                                                   |
-| ------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| [Ant Design Icons](https://ant.design/components/icon/)       | [MIT](https://github.com/ant-design/ant-design-icons/blob/master/LICENSE)                 |
-| [Bootstrap Icons](https://icons.getbootstrap.com/)            | [MIT](https://github.com/twbs/icons/blob/master/LICENSE.md)                               |
-| [Devicon](https://konpa.github.io/devicon/)                   | [MIT](https://github.com/konpa/devicon/blob/master/LICENSE)                               |
-| [Feather](https://feathericons.com/)                          | [MIT](https://github.com/feathericons/feather/blob/master/LICENSE)                        |
-| [Font Awesome](https://fontawesome.com/)                      | [CC BY 4.0 License](https://github.com/FortAwesome/Font-Awesome/blob/master/LICENSE.txt)  |
-| [Game Icons](https://game-icons.net/)                         | [CC BY 3.0](https://github.com/game-icons/icons/blob/master/license.txt)                  |
-| [Github Octicons](https://octicons.github.com/)               | [MIT](https://github.com/primer/octicons/blob/master/LICENSE)                             |
-| [Ionicons](https://ionicons.com/)                             | [MIT](https://github.com/ionic-team/ionicons/blob/master/LICENSE)                         |
-| [Material Design](https://material.io/resources/icons/)       | [Apache License 2.0](https://github.com/google/material-design-icons/blob/master/LICENSE) |
-| [Remix Icon](https://remixicon.com/)                          | [Apache License 2.0](https://github.com/Remix-Design/RemixIcon/blob/master/License)       |
-| [Typicons](http://s-ings.com/typicons/)                       | [CC BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/)                           |
-| [Weather Icons](https://erikflowers.github.io/weather-icons/) | [SIL OFL 1.1](http://scripts.sil.org/OFL)                                                 |
+| Icon Library                                                                   | License                                                                                   |
+| -------------------------------------------------------------------------------| ----------------------------------------------------------------------------------------- |
+| [Ant Design Icons](https://ant.design/components/icon/)                        | [MIT](https://github.com/ant-design/ant-design-icons/blob/master/LICENSE)                 |
+| [Bootstrap Icons](https://icons.getbootstrap.com/)                             | [MIT](https://github.com/twbs/icons/blob/master/LICENSE.md)                               |
+| [Devicon](https://konpa.github.io/devicon/)                                    | [MIT](https://github.com/konpa/devicon/blob/master/LICENSE)                               |
+| [Feather](https://feathericons.com/)                                           | [MIT](https://github.com/feathericons/feather/blob/master/LICENSE)                        |
+| [Font Awesome](https://fontawesome.com/)                                       | [CC BY 4.0 License](https://github.com/FortAwesome/Font-Awesome/blob/master/LICENSE.txt)  |
+| [Game Icons](https://game-icons.net/)                                          | [CC BY 3.0](https://github.com/game-icons/icons/blob/master/license.txt)                  |
+| [Github Octicons](https://octicons.github.com/)                                | [MIT](https://github.com/primer/octicons/blob/master/LICENSE)                             |
+| [Ionicons](https://ionicons.com/)                                              | [MIT](https://github.com/ionic-team/ionicons/blob/master/LICENSE)                         |
+| [Material Design](https://material.io/resources/icons/)                        | [Apache License 2.0](https://github.com/google/material-design-icons/blob/master/LICENSE) |
+| [Remix Icon](https://remixicon.com/)                                           | [Apache License 2.0](https://github.com/Remix-Design/RemixIcon/blob/master/License)       |
+| [Predix Design System Icons](https://www.predix-ui.com/#/elements/px-icon-set) | [Apache License 2.0](https://github.com/predixdesignsystem/px-icon-set/blob/master/LICENSE)
+| [Typicons](http://s-ings.com/typicons/)                                        | [CC BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/)                           |
+| [Weather Icons](https://erikflowers.github.io/weather-icons/)                  | [SIL OFL 1.1](http://scripts.sil.org/OFL)                                                 |
 
 You can add more icons by submitting pull requests or creating issues.
 
@@ -162,6 +163,7 @@ yarn build
 ```
 
 ### Preview
+
 The preview site is the [`react-icons`](https://react-icons.netlify.com/) website, built in [NextJS](https://nextjs.org/).
 
 ```bash
@@ -173,16 +175,74 @@ yarn start
 ```
 
 ### Demo
+
 The demo is a [Create React App](https://create-react-app.dev/) boilerplate with `react-icons` added as a dependency for easy testing.
 
-```bash
-cd packages/react-icons
-yarn build
+### How to add an icon set
 
-cd ../demo
-yarn start
+#### 1. Add new git submodule
+
+From the main directory (where this file is located) run the following command:
+
+```bash
+git submodule add --name <name> <git-repo-url-for-the-new-icon-set> packages/react-icons/src/icons/<name>
 ```
 
+#### 2. Modify **README.md** (this document)
+
+Add the name, URL, and the license link to the table in the `##Icons` section of this file.
+Keep the list in alphabetical order.
+
+#### 3. Modify **packages/react-icons/.gitignore**
+
+Add the two-letter folder name for the new icon set, e.g.:
+
+```text
+...
+/xy/
+...
+```
+
+#### 4. Modify **packages/react-icons/LICENSE**
+
+Add license details about the new icon set.
+
+#### 5. Modify **packages/react-icons/src/icons/index.js**
+
+Add the object with the following structure:
+
+```JavaScript
+{
+      id: "xy",                                    // Two-letter id
+      name: "e.g. Xenon Yellow Icons",             // The full icon set name
+      contents: [
+        {
+          files: path.resolve(__dirname, "<relative-path-to-git-submodule>/<path-to-svg-icons>/<filter>"),
+          formatter: name => `Xy${name}`            // So that all icon names from this set will start with "Xy"
+        }
+      ],
+      // URL of the github repo
+      projectUrl: "https://github.com/xy/xy-icons",
+      license: "Apache License Version 2.0",        // License type
+      licenseUrl: "http://www.apache.org/licenses/" // URL of the license definition
+}
+```
+
+to the `icons` array.
+
+#### 6. Once everything builds and looks right in the preview, create a pull request
+
+## Tips
+
+### SVG
+
+Svg is [supported](http://caniuse.com/#search=svg) by all major browsers.
+
+### Why ES6 import and not fonts
+
+With `react-icons`, you can serve only the needed icons instead of one big font file to the users, helping you to recognize which icons are used in your project.
+
+### Related
 ## Why React SVG components instead of fonts?
 
 SVG is [supported by all major browsers](http://caniuse.com/#search=svg). With `react-icons`, you can serve only the needed icons instead of one big font file to the users, helping you to recognize which icons are used in your project.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "eslint-plugin-node": "^7.0.1",
     "eslint-plugin-prettier": "^3.0.0",
     "eslint-plugin-promise": "^4.0.1",
+    "eslint-plugin-react": "^7.18.0",
     "eslint-plugin-standard": "^4.0.0",
     "lerna": "^3.20.2",
     "netlify-cli": "^2.30.0",

--- a/packages/react-icons/.gitignore
+++ b/packages/react-icons/.gitignore
@@ -16,5 +16,6 @@
 /ai/
 /bs/
 /ri/
+/px/
 README.md
 

--- a/packages/react-icons/LICENSE
+++ b/packages/react-icons/LICENSE
@@ -45,3 +45,6 @@ License: MIT https://opensource.org/licenses/MIT
 
 Remix Icon - https://github.com/Remix-Design/RemixIcon
 License: Apache License Version 2.0 http://www.apache.org/licenses/
+
+Predix Design System Icons - https://github.com/tromgy/px-icon-set
+License: Apache License Version 2.0 http://www.apache.org/licenses/

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -56,6 +56,7 @@
     "build-cjs": "tsc -p ./tsconfig.commonjs.json"
   },
   "dependencies": {
-    "camelcase": "^5.0.0"
+    "camelcase": "^5.0.0",
+    "ncp": "^2.0.0"
   }
 }

--- a/packages/react-icons/plugin/defaultImportConverter.js
+++ b/packages/react-icons/plugin/defaultImportConverter.js
@@ -3,11 +3,10 @@ module.exports = (babel, options) => {
     name: "default-import-converter",
     visitor: {
       ImportDeclaration(path) {
-        var spec = path.node.specifiers.map(
-          spec =>
-            options.keys.includes(spec.local.name)
-              ? babel.types.ImportDefaultSpecifier(spec.local)
-              : spec
+        var spec = path.node.specifiers.map(spec =>
+          options.keys.includes(spec.local.name)
+            ? babel.types.ImportDefaultSpecifier(spec.local)
+            : spec
         );
         path.node.specifiers = spec;
       }

--- a/packages/react-icons/scripts/build.js
+++ b/packages/react-icons/scripts/build.js
@@ -17,11 +17,35 @@ const LIB = path.resolve(rootDir, "./lib");
 async function getIconFiles(content) {
   return glob(content.files);
 }
+
 async function convertIconData(svg) {
   const $svg = cheerio.load(svg, { xmlMode: true })("svg");
 
+  // Convert SVG inline style attribute into an object for React consumption:
+  // e.g. style="fill: none;stroke: #00007f;stroke-linejoin: round" gets converted
+  // into  "style": {"fill": " none","stroke": " #00007f","strokeLinejoin": " round"}
+  const cssToObj = /** @type string */ css => {
+    try {
+      const result = {};
+
+      const cssAttributes = css.split(";");
+
+      for (const attr of cssAttributes) {
+        const pair = attr.split(":");
+
+        result[camelcase(pair[0])] = pair[1];
+      }
+
+      return result;
+    } catch (e) {
+      console.error(e);
+
+      return null;
+    }
+  };
+
   // filter/convert attributes
-  // 1. remove class attr
+  // 1. convert "class" attr to "className" for use with React JSX
   // 2. convert to camelcase ex: fill-opacity => fillOpacity
   const attrConverter = (
     /** @type {{[key: string]: string}} */ attribs,
@@ -31,10 +55,13 @@ async function convertIconData(svg) {
     Object.keys(attribs)
       .filter(
         name =>
-          ![
-            "class",
-            ...(tagName === "svg" ? ["xmlns", "xmlns:xlink", "xml:space", "width", "height"] : []) // if tagName is svg remove size attributes
-          ].includes(name)
+          !(
+            [
+              ...(tagName === "svg"
+                ? ["xmlns", "xmlns:xlink", "xml:space", "width", "height"]
+                : []) // if tagName is svg remove size attributes
+            ].includes(name) || name === "data-name"
+          ) // React doesn't like "data-name" (dataName) attribute in Predix icons
       )
       .reduce((obj, name) => {
         const newName = camelcase(name);
@@ -43,6 +70,12 @@ async function convertIconData(svg) {
             if (attribs[name] === "none") {
               obj[newName] = attribs[name];
             }
+            break;
+          case "class": // internal CSS
+            obj["className"] = attribs[name];
+            break;
+          case "style": // inline style
+            obj["style"] = cssToObj(attribs[name]);
             break;
           default:
             obj[newName] = attribs[name];
@@ -54,20 +87,35 @@ async function convertIconData(svg) {
   // convert to [ { tag: 'path', attr: { d: 'M436 160c6.6 ...', ... }, child: { ... } } ]
   const elementToTree = (/** @type {Cheerio} */ element) =>
     element
-      .filter((_, e) => e.tagName && !["style"].includes(e.tagName))
-      .map((_, e) => ({
-        tag: e.tagName,
-        attr: attrConverter(e.attribs, e.tagName),
-        child:
-          e.children && e.children.length
-            ? elementToTree(cheerio(e.children))
-            : undefined
-      }))
+      .filter((_, e) => e.tagName)
+      .map((_, e) => {
+        const childTags = [];
+        let textContent;
+
+        // Separate the text content child from all other children
+        for (const child of e.children) {
+          if (child.type === "text") {
+            textContent = child.data;
+          } else {
+            childTags.push(child);
+          }
+        }
+
+        return {
+          tag: e.tagName,
+          attr: attrConverter(e.attribs, e.tagName),
+          child: childTags.length
+            ? elementToTree(cheerio(childTags))
+            : undefined,
+          content: textContent
+        };
+      })
       .get();
 
   const tree = elementToTree($svg);
   return tree[0]; // like: [ { tag: 'path', attr: { d: 'M436 160c6.6 ...', ... }, child: { ... } } ]
 }
+
 function generateIconRow(icon, formattedName, iconData, type = "module") {
   switch (type) {
     case "module":
@@ -114,7 +162,13 @@ async function dirInit() {
   const write = (filePath, str) =>
     writeFile(path.resolve(DIST, ...filePath), str, "utf8").catch(ignore);
 
-  const initFiles = ["index.d.ts", "index.esm.js", "index.js", "all.js", "all.d.ts"];
+  const initFiles = [
+    "index.d.ts",
+    "index.esm.js",
+    "index.js",
+    "all.js",
+    "all.d.ts"
+  ];
 
   const gitignore =
     [
@@ -253,19 +307,43 @@ async function writeLicense() {
   await appendFile(path.resolve(rootDir, "LICENSE"), iconLicenses, "utf8");
 }
 
-async function writeEntryPoints(){
+async function writeEntryPoints() {
   const appendFile = promisify(fs.appendFile);
   const generateEntryCjs = function() {
-    return `module.exports = require('./lib/cjs/index.js');`
-  }
-  const generateEntryMjs = function(filename = 'index.js'){
+    return `module.exports = require('./lib/cjs/index.js');`;
+  };
+  const generateEntryMjs = function(filename = "index.js") {
     return `import * as m from './lib/esm/${filename}'
 export default m
-    `
-  }
+    `;
+  };
   await appendFile(path.resolve(DIST, "index.js"), generateEntryCjs(), "utf8");
-  await appendFile(path.resolve(DIST, "index.esm.js"), generateEntryMjs(), "utf8");
-  await appendFile(path.resolve(DIST, "index.d.ts"), generateEntryMjs('index.d.ts'), "utf8");
+  await appendFile(
+    path.resolve(DIST, "index.esm.js"),
+    generateEntryMjs(),
+    "utf8"
+  );
+  await appendFile(
+    path.resolve(DIST, "index.d.ts"),
+    generateEntryMjs("index.d.ts"),
+    "utf8"
+  );
+}
+
+async function pushToPreview() {
+  const ncp = require("ncp").ncp;
+
+  for (const icon of icons) {
+    const sourceDir = path.join(__dirname, "..", icon.id);
+    const targetDir = path.join(
+      "../preview/node_modules/react-icons/",
+      icon.id
+    );
+
+    await ncp(sourceDir, targetDir);
+
+    console.log(`pushed ${sourceDir} to ${targetDir}`);
+  }
 }
 
 async function main() {
@@ -277,6 +355,7 @@ async function main() {
     for (const icon of icons) {
       await writeIconModule(icon);
     }
+    await pushToPreview();
     console.log("done");
   } catch (e) {
     console.error(e);

--- a/packages/react-icons/src/iconBase.tsx
+++ b/packages/react-icons/src/iconBase.tsx
@@ -6,15 +6,42 @@ export interface IconTree {
   tag: string;
   attr: {[key: string]: string};
   child: IconTree[];
+  content: string;
 }
-
 
 function Tree2Element(tree: IconTree[]): React.ReactElement<{}>[] {
-  return tree && tree.map((node, i) => React.createElement(node.tag, {key: i, ...node.attr}, Tree2Element(node.child)));
+  return tree && tree.map((node, i) => React.createElement(node.tag, {key: i, ...node.attr}, node.content, Tree2Element(node.child)));
 }
+
+function HasStrokes(svg: any) : boolean {
+  for (const prop in svg) {
+    if (prop[0] === '_') {
+      continue; // don't go into any "private" properties
+    }
+    if (prop === "stroke") {
+      return true;
+    } else if (typeof svg[prop] === "object") {
+      const result = HasStrokes(svg[prop]);
+      if (result) {
+        return result;
+      }
+    } else if (prop === "content") {
+      // check if this content is for the <style> tag
+      if (svg["tag"] === "style") {
+        // "content" may have styles for the stroke
+        if (svg[prop].includes("stroke:")) {
+          return true;
+        }
+      }
+    }
+  }
+
+  return false;
+}
+
 export function GenIcon(data: IconTree) {
   return (props: IconBaseProps) => (
-    <IconBase attr={{...data.attr}} {...props}>
+    <IconBase attr={{...data.attr}} {...props} hasStrokes={HasStrokes(data)}>
       {Tree2Element(data.child)}
     </IconBase>
   );
@@ -25,22 +52,27 @@ export interface IconBaseProps extends React.SVGAttributes<SVGElement> {
   size?: string | number;
   color?: string;
   title?: string;
+  hasStrokes?: boolean;
 }
 
 export type IconType = (props: IconBaseProps) => JSX.Element;
+
 export function IconBase(props:IconBaseProps & { attr: {} | undefined }): JSX.Element {
   const elem = (conf: IconContext) => {
     const computedSize = props.size || conf.size || "1em";
     let className;
     if (conf.className) className = conf.className;
     if (props.className) className = (className ? className + ' ' : '') + props.className;
-    const {attr, title, ...svgProps} = props;
+    const {attr, title, hasStrokes, ...svgProps} = props;
+
+    // If the icon has explicit "stroke" attribute, do NOT set zero stroke width
+    const stroke =  hasStrokes? null : { strokeWidth: 0 };
 
     return (
       <svg
         stroke="currentColor"
         fill="currentColor"
-        strokeWidth="0"
+        {...stroke} 
         {...conf.attr}
         {...attr}
         {...svgProps}

--- a/packages/react-icons/src/icons/index.js
+++ b/packages/react-icons/src/icons/index.js
@@ -267,6 +267,21 @@ module.exports = {
       projectUrl: "https://github.com/Remix-Design/RemixIcon",
       license: "Apache License Version 2.0",
       licenseUrl: "http://www.apache.org/licenses/"
+    },
+    {
+      id: "px",
+      name: "Predix Design System Icons",
+      contents: [
+        {
+          files: path.resolve(__dirname, "px-icon-set/icons/src-*/*.svg"),
+          formatter: name => `Px${name}`
+        }
+      ],
+      // use this repo for the time being, the official one doesn't seem to be
+      // maintaned anymore
+      projectUrl: "https://github.com/tromgy/px-icon-set",
+      license: "Apache License Version 2.0",
+      licenseUrl: "http://www.apache.org/licenses/"
     }
   ]
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3746,6 +3746,15 @@ array-includes@^3.0.3:
     define-properties "^1.1.2"
     es-abstract "^1.7.0"
 
+array-includes@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.1.1.tgz#cdd67e6852bdf9c1215460786732255ed2459348"
+  integrity sha512-c2VXaCHl7zPsvpkFsw4nxvFie4fh1ur9bpcgsVkIjqn0H/Xwdg+7fv3n2r/isyS8EBj5b06M9kHyZuIr4El6WQ==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.0"
+    is-string "^1.0.5"
+
 array-union@^1.0.1, array-union@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
@@ -6942,7 +6951,7 @@ es-abstract@^1.11.0, es-abstract@^1.12.0, es-abstract@^1.5.1, es-abstract@^1.7.0
     is-regex "^1.0.4"
     object-keys "^1.0.12"
 
-es-abstract@^1.13.0, es-abstract@^1.17.0-next.0, es-abstract@^1.17.0-next.1:
+es-abstract@^1.13.0, es-abstract@^1.17.0, es-abstract@^1.17.0-next.0, es-abstract@^1.17.0-next.1:
   version "1.17.4"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.4.tgz#e3aedf19706b20e7c2594c35fc0d57605a79e184"
   integrity sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==
@@ -7228,6 +7237,21 @@ eslint-plugin-react@7.16.0:
     object.values "^1.1.0"
     prop-types "^15.7.2"
     resolve "^1.12.0"
+
+eslint-plugin-react@^7.18.0:
+  version "7.18.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.18.0.tgz#2317831284d005b30aff8afb7c4e906f13fa8e7e"
+  integrity sha512-p+PGoGeV4SaZRDsXqdj9OWcOrOpZn8gXoGPcIQTzo2IDMbAKhNDnME9myZWqO3Ic4R3YmwAZ1lDjWl2R2hMUVQ==
+  dependencies:
+    array-includes "^3.1.1"
+    doctrine "^2.1.0"
+    has "^1.0.3"
+    jsx-ast-utils "^2.2.3"
+    object.entries "^1.1.1"
+    object.fromentries "^2.0.2"
+    object.values "^1.1.1"
+    prop-types "^15.7.2"
+    resolve "^1.14.2"
 
 eslint-plugin-standard@^4.0.0:
   version "4.0.0"
@@ -10503,7 +10527,7 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-jsx-ast-utils@^2.2.1:
+jsx-ast-utils@^2.2.1, jsx-ast-utils@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-2.2.3.tgz#8a9364e402448a3ce7f14d357738310d9248054f"
   integrity sha512-EdIHFMm+1BPynpKOpdPqiOsvnIrInRGJD7bzPZdPkjitQEqpdpUuFpq4T0npZFKTiB3RhWFdGN+oqOJIdhDhQA==
@@ -11575,6 +11599,11 @@ natural-compare@^1.4.0:
 natural-orderby@^2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/natural-orderby/-/natural-orderby-2.0.3.tgz#8623bc518ba162f8ff1cdb8941d74deb0fdcc016"
+
+ncp@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
+  integrity sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=
 
 nearley@^2.7.10:
   version "2.16.0"


### PR DESCRIPTION
This is to address issue #282. Icons having `stroke` attribute will now render properly. Fill-based (stroke-less) icons will render as before.  

Here's what this pull request tries to accomplish:

- Add support for SVGs with: inline styles, internal CSS, stroke presentation attributes, and `<text>`
- Add Predix Design System icons
- Change the build process to copy the artifacts into the preview for easy verification
- Disable linting of generated code (it takes hours to lint it, and it's of little value)
- Add react plugin for eslint, so the demo code can be linted properly as JSX
- Fix few of the remaining linting errors
- Document how to add icons in README.md