### PR TITLE
Add title props to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ import { IconContext } from "react-icons";
 | `className` | `undefined`           |                                 |
 | `style`     | `undefined`           | Can overwrite size and color    |
 | `attr`      | `undefined`           | Overwritten by other attributes |
+| `title`     | `undefined`           | Icon description for accessibility |
 
 ## Migrating from version 2 -> 3
 


### PR DESCRIPTION
I noticed that this was added in [v3.7.0](https://github.com/react-icons/react-icons/releases/tag/v3.7.0) but not yet reflected in the README.