### PR TITLE
Fix typing issue

### DIFF
--- a/packages/react-icons/src/iconBase.tsx
+++ b/packages/react-icons/src/iconBase.tsx
@@ -28,7 +28,7 @@ export interface IconBaseProps extends React.SVGAttributes<SVGElement> {
 }
 
 export type IconType = (props: IconBaseProps) => JSX.Element;
-export function IconBase(props:IconBaseProps & { attr: {} | undefined }): JSX.Element {
+export function IconBase(props:IconBaseProps & { attr?: {} }): JSX.Element {
   const elem = (conf: IconContext) => {
     const computedSize = props.size || conf.size || "1em";
     let className;


### PR DESCRIPTION
The previous typing required the `attr` to be there, even though it is defined as undefined. By making it optional it is truly an optional property and does not have to be defined when consuming the component.