### PR TITLE
Change the react-icons url to the most up to date deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img src="https://rawgit.com/gorangajic/react-icons/master/react-icons.svg" width="120" alt="React Icons">
 
-# [React Icons](https://react-icons.netlify.com)
+# [React Icons](https://react-icons.github.io/react-icons/)
 
 [![npm][npm-image]][npm-url]
 


### PR DESCRIPTION
The README page is currently pointing new users to website with missing content and libraries that react-icons already supports.
The github deployment is more up to date than the outdated netflify deployment, this PR is attempting to point to the most up to date website deployment.

