### PR TITLE
Fix #154 by allowing absolute imports

### DIFF
--- a/packages/react-icons/scripts/build.js
+++ b/packages/react-icons/scripts/build.js
@@ -85,8 +85,8 @@ function generateIconRow(icon, formattedName, iconData, type = "module") {
     case "common":
       return (
         `var ${formattedName} = require('./${formattedName}');\n`+
-        `module.exports.${formattedName}.displayName = "${formattedName}";\n` +
-        `module.exports.${formattedName}.iconSet = "${icon.id}";\n` +
+        `${formattedName}.displayName = "${formattedName}";\n` +
+        `${formattedName}.iconSet = "${icon.id}";\n` +
         `module.exports.${formattedName} = ${formattedName};\n\n`
       );
     case "dts":


### PR DESCRIPTION
Fix #154 by giving developers the option of either using absolute imports or destructuring. 

It generates a unique file for each icon. 

This will eliminate the assumption that the build systems are configured for tree shaking.
