### PR TITLE
Download all icons form game-icons

### DIFF
--- a/packages/react-icons/src/icons/index.js
+++ b/packages/react-icons/src/icons/index.js
@@ -107,7 +107,7 @@ module.exports = {
         {
           files: path.resolve(
             __dirname,
-            "game-icons-inverted/+(carl-olsen|andymeneely|cathelineau|darkzaitzev|delapouite|faithtoken|generalace135|guard13007|heavenly-dog|irongamer|john-colburn|kier-heyl|lorc|lord-berandas|quoting|rihlsul|sbed|skoll|sparker|spencerdub|zajkonur)/originals/svg/000000/transparent/*.svg"
+            "game-icons-inverted/+(carl-olsen|andymeneely|cathelineau|darkzaitzev|delapouite|faithtoken|generalace135|guard13007|heavenly-dog|irongamer|john-colburn|kier-heyl|lorc|lord-berandas|quoting|rihlsul|sbed|skoll|sparker|spencerdub|zajkonur)/.*.svg"
           ),
           formatter: name => `Gi${name}`
         },


### PR DESCRIPTION
With this PR, we are downloading all the icons from the website GameIcons in the correct format.

This PR will resolve the issue:
https://github.com/react-icons/react-icons/issues/360