### PR TITLE
Change not to set the size attribute to svg element

### DIFF
--- a/packages/react-icons/src/iconBase.tsx
+++ b/packages/react-icons/src/iconBase.tsx
@@ -30,11 +30,11 @@ export interface IconBaseProps extends React.SVGAttributes<SVGElement> {
 export type IconType = (props: IconBaseProps) => JSX.Element;
 export function IconBase(props:IconBaseProps & { attr?: {} }): JSX.Element {
   const elem = (conf: IconContext) => {
-    const computedSize = props.size || conf.size || "1em";
+    const {attr, size, title, ...svgProps} = props;
+    const computedSize = size || conf.size || "1em";
     let className;
     if (conf.className) className = conf.className;
     if (props.className) className = (className ? className + ' ' : '') + props.className;
-    const {attr, title, ...svgProps} = props;
 
     return (
       <svg


### PR DESCRIPTION
When use the `size` property to change icon size, the `size` attribute is set to svg element like this.

![スクリーンショット 2020-11-25 17 55 49 2](https://user-images.githubusercontent.com/270422/100206959-5bd98700-2f4a-11eb-9d4d-896a85116eaa.png)

But the `size` attribute is not allowed on svg element, so this PR changes not to set the `size` attribute to svg element.