### PR TITLE
Preview search fixes and enhancements

### DIFF
--- a/packages/preview/next.config.js
+++ b/packages/preview/next.config.js
@@ -30,7 +30,5 @@ module.exports = withPWA({
     return config;
   },
   assetPrefix: process.env.BASE_PATH || "",
-  publicRuntimeConfig: {
-    basePath: process.env.BASE_PATH || "",
-  },
+  basePath: process.env.BASE_PATH || "",
 });

--- a/packages/preview/src/components/@core/icon/index.tsx
+++ b/packages/preview/src/components/@core/icon/index.tsx
@@ -2,7 +2,7 @@ import toast from "cogo-toast";
 import copy from "copy-to-clipboard";
 import React from "react";
 
-function Icon({ icon, name }) {
+function Icon({ icon, name, highlightPattern = null }) {
   const copyToClipboard = () => {
     copy(name);
     toast.success(`Copied '${name}' to clipboard`, {
@@ -10,10 +10,18 @@ function Icon({ icon, name }) {
     });
   };
 
+  const highlightedName = () => {
+    if (highlightPattern)
+      return name
+        .split(highlightPattern)
+        .map((part) => (part.match(highlightPattern) ? <b>{part}</b> : part));
+    return name;
+  };
+
   return (
     <div className="item" tabIndex={0} onClick={copyToClipboard} key={name}>
       <div className="icon h2">{typeof icon === "function" && icon()}</div>
-      <div className="name">{name}</div>
+      <div className="name">{highlightedName()}</div>
     </div>
   );
 }

--- a/packages/preview/src/components/@core/sidebar/index.tsx
+++ b/packages/preview/src/components/@core/sidebar/index.tsx
@@ -12,13 +12,19 @@ export default function Sidebar() {
   const iconsList = ALL_ICONS.sort((a, b) => (a.name > b.name ? 1 : -1));
   const router = useRouter();
   const [isOpen, setIsOpen] = useState(false);
+  const [inputQuery, setInputQuery] = useState(null);
 
   const { query, setQuery, setResults } = React.useContext(Context);
 
+  const setQueryEveywhere = (query) => {
+    setQuery(query); // Context
+    setInputQuery(query); // State for this component
+  };
+
   const onSearch = e => {
     const query = e.target.value.toLowerCase();
-    router.push({ pathname: searchPath, query: { q: query } });
-    setQuery(query);
+    router.push({ pathname: searchPath, query: query ? { q: query } : null });
+    setQueryEveywhere(query);
     setResults(prevResult => {
       return {}
     });
@@ -47,7 +53,7 @@ export default function Sidebar() {
           onFocus={goToSearch}
           onBlur={onBlur}
           onChange={onSearch}
-          value={query}
+          value={inputQuery !== null ? inputQuery : query}
         />
       </div>
 
@@ -60,7 +66,12 @@ export default function Sidebar() {
         {iconsList.map(icon => (
           <li key={icon.id}>
             <ActiveLink href={{ pathname: "icons", query: { name: icon.id } }}>
-              <a className="rounded px2 py1">{icon.name}</a>
+              <a
+                className="rounded px2 py1"
+                onClick={(e) => setQueryEveywhere("")}
+              >
+                {icon.name}
+              </a>
             </ActiveLink>
           </li>
         ))}

--- a/packages/preview/src/components/@core/sidebar/index.tsx
+++ b/packages/preview/src/components/@core/sidebar/index.tsx
@@ -6,22 +6,26 @@ import React, { useState } from "react";
 import ActiveLink from "../active-link";
 import Heading from "../heading";
 
+const searchPath = "/search";
+
 export default function Sidebar() {
   const iconsList = ALL_ICONS.sort((a, b) => (a.name > b.name ? 1 : -1));
   const router = useRouter();
   const [isOpen, setIsOpen] = useState(false);
 
-  const { setQuery, setResults } = React.useContext(Context);
+  const { query, setQuery, setResults } = React.useContext(Context);
 
   const onSearch = e => {
-    setQuery(e.target.value.toLowerCase());
+    const query = e.target.value.toLowerCase();
+    router.push({ pathname: searchPath, query: { q: query } });
+    setQuery(query);
     setResults(prevResult => {
       return {}
     });
   };
 
   const goToSearch = e => {
-    router.push("/search");
+    if (!router.asPath.includes(searchPath)) router.push(searchPath);
   };
 
   const onBlur = event => {
@@ -43,6 +47,7 @@ export default function Sidebar() {
           onFocus={goToSearch}
           onBlur={onBlur}
           onChange={onSearch}
+          value={query}
         />
       </div>
 

--- a/packages/preview/src/components/pages/search/index.tsx
+++ b/packages/preview/src/components/pages/search/index.tsx
@@ -15,26 +15,27 @@ export default function SearchPageComponent() {
       0
   }
 
-  return query.length > 2 ? (
-    <>
-      <h2>
-        Results for: <i>{query}</i>
-      </h2>
-      <div className="icons">
-        {allIcons.map(icon => (
-          <SearchIconSet
-            key={icon.id}
-            icon={icon}
-            query={query}
-            setResults={setResults} />
-        ))}
-      </div>
-      { 
-        getTotal(results) === 0 &&
-        <h3>No icons found</h3>
-      }
-    </>
-  ) : (
-    <h2>Please enter at least 3 characters to search...</h2>
-  );
+  if (query.length > 2) {
+    const hightlightPattern = new RegExp(`(${query})`, "i");
+    return (
+      <>
+        <h2>
+          Results for: <i>{query}</i>
+        </h2>
+        <div className="icons">
+          {allIcons.map((icon) => (
+            <SearchIconSet
+              key={icon.id}
+              icon={icon}
+              query={query}
+              setResults={setResults}
+              highlightPattern={hightlightPattern}
+            />
+          ))}
+        </div>
+        {getTotal(results) === 0 && <h3>No icons found</h3>}
+      </>
+    );
+  }
+  return <h2>Please enter at least 3 characters to search...</h2>;
 }

--- a/packages/preview/src/components/pages/search/index.tsx
+++ b/packages/preview/src/components/pages/search/index.tsx
@@ -7,13 +7,7 @@ import SearchIconSet from "./search-iconset";
 export default function SearchPageComponent() {
   const allIcons = ALL_ICONS;
 
-  const { query, results, setResults } = React.useContext(Context);
-
-  const getTotal = (results: object) => {
-    return results ? 
-      Object.values(results).reduce((p: number, c: number) => p + c, 0) :
-      0
-  }
+  const { query } = React.useContext(Context);
 
   if (query.length > 2) {
     const hightlightPattern = new RegExp(`(${query})`, "i");
@@ -28,12 +22,11 @@ export default function SearchPageComponent() {
               key={icon.id}
               icon={icon}
               query={query}
-              setResults={setResults}
               highlightPattern={hightlightPattern}
             />
           ))}
         </div>
-        {getTotal(results) === 0 && <h3>No icons found</h3>}
+         <h3 className="no-results"/>
       </>
     );
   }

--- a/packages/preview/src/components/pages/search/search-iconset.tsx
+++ b/packages/preview/src/components/pages/search/search-iconset.tsx
@@ -5,7 +5,7 @@ import { getIcons } from "@utils/getIcons";
 
 import SearchPageIconLoading from "./loading";
 
-export default function SearchIconSet({ icon, query, setResults }) {
+export default function SearchIconSet({ icon, query, setResults, highlightPattern }) {
   const IconSet = loadable.lib(() => getIcons(icon.id));
 
   return (
@@ -16,16 +16,21 @@ export default function SearchIconSet({ icon, query, setResults }) {
         return (
           <>
             {found.map(name => (
-                <Icon key={name} icon={icons[name]} name={name} />
-              ))}
-              {setResults(prevResults => {
-                return prevResults.hasOwnProperty(icon.id) ?
-                  prevResults :
-                  {
+              <Icon
+                key={name}
+                icon={icons[name]}
+                name={name}
+                highlightPattern={highlightPattern}
+              />
+            ))}
+            {setResults(prevResults => {
+              return prevResults.hasOwnProperty(icon.id) ?
+                prevResults :
+                {
                     ...prevResults,
-                    [icon.id]: found.length
-                  }
-              })}
+                  [icon.id]: found.length
+                }
+            })}
           </>
         )
       }}

--- a/packages/preview/src/components/pages/search/search-iconset.tsx
+++ b/packages/preview/src/components/pages/search/search-iconset.tsx
@@ -5,7 +5,7 @@ import { getIcons } from "@utils/getIcons";
 
 import SearchPageIconLoading from "./loading";
 
-export default function SearchIconSet({ icon, query, setResults, highlightPattern }) {
+export default function SearchIconSet({ icon, query, highlightPattern }) {
   const IconSet = loadable.lib(() => getIcons(icon.id));
 
   return (
@@ -23,14 +23,6 @@ export default function SearchIconSet({ icon, query, setResults, highlightPatter
                 highlightPattern={highlightPattern}
               />
             ))}
-            {setResults(prevResults => {
-              return prevResults.hasOwnProperty(icon.id) ?
-                prevResults :
-                {
-                    ...prevResults,
-                  [icon.id]: found.length
-                }
-            })}
           </>
         )
       }}

--- a/packages/preview/src/pages/search.tsx
+++ b/packages/preview/src/pages/search.tsx
@@ -1,8 +1,16 @@
 import Container from "@components/@core/container";
 import SearchPageComponent from "@components/pages/search";
 import React from "react";
+import { useRouter } from "next/router";
+import { Context } from "@utils/search-context";
 
 export default function SearchPage() {
+  const router = useRouter();
+  const { q } = router.query;
+  const { query, setQuery } = React.useContext(Context);
+
+  if (!query && q) setQuery(q);
+
   return (
     <Container title="🔍 Search">
       <SearchPageComponent />

--- a/packages/preview/src/styles/_components.scss
+++ b/packages/preview/src/styles/_components.scss
@@ -237,3 +237,7 @@ a {
     display: none;
   }
 }
+
+.icons:empty + .no-results:after {
+  content: "No icons found";
+}


### PR DESCRIPTION
## Changes
- Fix the problems with the base path (404 after refreshing page). I'm not sure it's the best way to do it, but you can check the result after `BASE_PATH=/react-icons NODE_ENV=production yarn build` in the demo.
- Add search url query param with persistence.
- Added highlighting of matches in the search.

### Demo
https://gabrii.github.io/react-icons/search?q=react