### PR TITLE
Build process improvements, "new" part 1 of the older PR #284 

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,3 +5,7 @@
 packages/react-icons/lib/*
 packages/react-icons/src/icons/*
 !packages/react-icons/src/icons/index.js
+
+# Ignore generated files
+packages/react-icons/??
+packages/react-icons/*.js

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,17 +4,24 @@
     "standard",
     "prettier",
     "prettier/react",
-    "prettier/standard"
+    "prettier/standard",
+    "plugin:react/recommended"
   ],
   "env": {
     "jest": true,
     "browser": true
   },
   "plugins": [
-    "prettier"
+    "prettier",
+    "react"
   ],
   "rules": {
     "prettier/prettier": "error",
-    "no-unused-vars":"warn"
+    "no-unused-vars": "warn"
+  },
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "eslint-plugin-node": "^7.0.1",
     "eslint-plugin-prettier": "^3.0.0",
     "eslint-plugin-promise": "^4.0.1",
+    "eslint-plugin-react": "^7.18.0",
     "eslint-plugin-standard": "^4.0.0",
     "lerna": "^3.20.2",
     "netlify-cli": "^2.30.0",

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -56,6 +56,7 @@
     "build-cjs": "tsc -p ./tsconfig.commonjs.json"
   },
   "dependencies": {
-    "camelcase": "^5.0.0"
+    "camelcase": "^5.0.0",
+    "ncp": "^2.0.0"
   }
 }

--- a/packages/react-icons/plugin/defaultImportConverter.js
+++ b/packages/react-icons/plugin/defaultImportConverter.js
@@ -3,11 +3,10 @@ module.exports = (babel, options) => {
     name: "default-import-converter",
     visitor: {
       ImportDeclaration(path) {
-        var spec = path.node.specifiers.map(
-          spec =>
-            options.keys.includes(spec.local.name)
-              ? babel.types.ImportDefaultSpecifier(spec.local)
-              : spec
+        var spec = path.node.specifiers.map(spec =>
+          options.keys.includes(spec.local.name)
+            ? babel.types.ImportDefaultSpecifier(spec.local)
+            : spec
         );
         path.node.specifiers = spec;
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3746,6 +3746,15 @@ array-includes@^3.0.3:
     define-properties "^1.1.2"
     es-abstract "^1.7.0"
 
+array-includes@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.1.1.tgz#cdd67e6852bdf9c1215460786732255ed2459348"
+  integrity sha512-c2VXaCHl7zPsvpkFsw4nxvFie4fh1ur9bpcgsVkIjqn0H/Xwdg+7fv3n2r/isyS8EBj5b06M9kHyZuIr4El6WQ==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.0"
+    is-string "^1.0.5"
+
 array-union@^1.0.1, array-union@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
@@ -6942,7 +6951,7 @@ es-abstract@^1.11.0, es-abstract@^1.12.0, es-abstract@^1.5.1, es-abstract@^1.7.0
     is-regex "^1.0.4"
     object-keys "^1.0.12"
 
-es-abstract@^1.13.0, es-abstract@^1.17.0-next.0, es-abstract@^1.17.0-next.1:
+es-abstract@^1.13.0, es-abstract@^1.17.0, es-abstract@^1.17.0-next.0, es-abstract@^1.17.0-next.1:
   version "1.17.4"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.4.tgz#e3aedf19706b20e7c2594c35fc0d57605a79e184"
   integrity sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==
@@ -7228,6 +7237,21 @@ eslint-plugin-react@7.16.0:
     object.values "^1.1.0"
     prop-types "^15.7.2"
     resolve "^1.12.0"
+
+eslint-plugin-react@^7.18.0:
+  version "7.18.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.18.0.tgz#2317831284d005b30aff8afb7c4e906f13fa8e7e"
+  integrity sha512-p+PGoGeV4SaZRDsXqdj9OWcOrOpZn8gXoGPcIQTzo2IDMbAKhNDnME9myZWqO3Ic4R3YmwAZ1lDjWl2R2hMUVQ==
+  dependencies:
+    array-includes "^3.1.1"
+    doctrine "^2.1.0"
+    has "^1.0.3"
+    jsx-ast-utils "^2.2.3"
+    object.entries "^1.1.1"
+    object.fromentries "^2.0.2"
+    object.values "^1.1.1"
+    prop-types "^15.7.2"
+    resolve "^1.14.2"
 
 eslint-plugin-standard@^4.0.0:
   version "4.0.0"
@@ -10503,7 +10527,7 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-jsx-ast-utils@^2.2.1:
+jsx-ast-utils@^2.2.1, jsx-ast-utils@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-2.2.3.tgz#8a9364e402448a3ce7f14d357738310d9248054f"
   integrity sha512-EdIHFMm+1BPynpKOpdPqiOsvnIrInRGJD7bzPZdPkjitQEqpdpUuFpq4T0npZFKTiB3RhWFdGN+oqOJIdhDhQA==
@@ -11575,6 +11599,11 @@ natural-compare@^1.4.0:
 natural-orderby@^2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/natural-orderby/-/natural-orderby-2.0.3.tgz#8623bc518ba162f8ff1cdb8941d74deb0fdcc016"
+
+ncp@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
+  integrity sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=
 
 nearley@^2.7.10:
   version "2.16.0"


### PR DESCRIPTION
This is being submitted as part 1 of [the older PR](https://github.com/react-icons/react-icons/pull/284)

Here's what this pull request tries to accomplish:

- Change the build process to copy the artifacts into the preview for easy verification
- Disable linting of generated code (it takes hours to lint it, and it's of little value)
- Add react plugin for eslint, so the demo code can be linted properly as JSX
- Fix few of the remaining linting errors