### PR TITLE
Add support for stroke-based icons, "new" part 2 of the older PR #284

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,6 @@
 [submodule "RemixIcon"]
 	path = packages/react-icons/src/icons/RemixIcon
 	url = https://github.com/Remix-Design/RemixIcon.git
+[submodule "px-icon-set"]
+	path = packages/react-icons/src/icons/px-icon-set
+	url = https://github.com/tromgy/px-icon-set.git

--- a/README.md
+++ b/README.md
@@ -39,20 +39,21 @@ For example, to use an icon from **Material Design**, your import would be: `imp
 
 ## Icons
 
-| Icon Library                                                  | License                                                                                   |
-| ------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| [Ant Design Icons](https://ant.design/components/icon/)       | [MIT](https://github.com/ant-design/ant-design-icons/blob/master/LICENSE)                 |
-| [Bootstrap Icons](https://icons.getbootstrap.com/)            | [MIT](https://github.com/twbs/icons/blob/master/LICENSE.md)                               |
-| [Devicon](https://konpa.github.io/devicon/)                   | [MIT](https://github.com/konpa/devicon/blob/master/LICENSE)                               |
-| [Feather](https://feathericons.com/)                          | [MIT](https://github.com/feathericons/feather/blob/master/LICENSE)                        |
-| [Font Awesome](https://fontawesome.com/)                      | [CC BY 4.0 License](https://github.com/FortAwesome/Font-Awesome/blob/master/LICENSE.txt)  |
-| [Game Icons](https://game-icons.net/)                         | [CC BY 3.0](https://github.com/game-icons/icons/blob/master/license.txt)                  |
-| [Github Octicons](https://octicons.github.com/)               | [MIT](https://github.com/primer/octicons/blob/master/LICENSE)                             |
-| [Ionicons](https://ionicons.com/)                             | [MIT](https://github.com/ionic-team/ionicons/blob/master/LICENSE)                         |
-| [Material Design](https://material.io/resources/icons/)       | [Apache License 2.0](https://github.com/google/material-design-icons/blob/master/LICENSE) |
-| [Remix Icon](https://remixicon.com/)                          | [Apache License 2.0](https://github.com/Remix-Design/RemixIcon/blob/master/License)       |
-| [Typicons](http://s-ings.com/typicons/)                       | [CC BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/)                           |
-| [Weather Icons](https://erikflowers.github.io/weather-icons/) | [SIL OFL 1.1](http://scripts.sil.org/OFL)                                                 |
+| Icon Library                                                                   | License                                                                                   |
+| -------------------------------------------------------------------------------| ----------------------------------------------------------------------------------------- |
+| [Ant Design Icons](https://ant.design/components/icon/)                        | [MIT](https://github.com/ant-design/ant-design-icons/blob/master/LICENSE)                 |
+| [Bootstrap Icons](https://icons.getbootstrap.com/)                             | [MIT](https://github.com/twbs/icons/blob/master/LICENSE.md)                               |
+| [Devicon](https://konpa.github.io/devicon/)                                    | [MIT](https://github.com/konpa/devicon/blob/master/LICENSE)                               |
+| [Feather](https://feathericons.com/)                                           | [MIT](https://github.com/feathericons/feather/blob/master/LICENSE)                        |
+| [Font Awesome](https://fontawesome.com/)                                       | [CC BY 4.0 License](https://github.com/FortAwesome/Font-Awesome/blob/master/LICENSE.txt)  |
+| [Game Icons](https://game-icons.net/)                                          | [CC BY 3.0](https://github.com/game-icons/icons/blob/master/license.txt)                  |
+| [Github Octicons](https://octicons.github.com/)                                | [MIT](https://github.com/primer/octicons/blob/master/LICENSE)                             |
+| [Ionicons](https://ionicons.com/)                                              | [MIT](https://github.com/ionic-team/ionicons/blob/master/LICENSE)                         |
+| [Material Design](https://material.io/resources/icons/)                        | [Apache License 2.0](https://github.com/google/material-design-icons/blob/master/LICENSE) |
+| [Remix Icon](https://remixicon.com/)                                           | [Apache License 2.0](https://github.com/Remix-Design/RemixIcon/blob/master/License)       |
+| [Predix Design System Icons](https://www.predix-ui.com/#/elements/px-icon-set) | [Apache License 2.0](https://github.com/predixdesignsystem/px-icon-set/blob/master/LICENSE)
+| [Typicons](http://s-ings.com/typicons/)                                        | [CC BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/)                           |
+| [Weather Icons](https://erikflowers.github.io/weather-icons/)                  | [SIL OFL 1.1](http://scripts.sil.org/OFL)                                                 |
 
 You can add more icons by submitting pull requests or creating issues.
 
@@ -162,6 +163,7 @@ yarn build
 ```
 
 ### Preview
+
 The preview site is the [`react-icons`](https://react-icons.netlify.com/) website, built in [NextJS](https://nextjs.org/).
 
 ```bash
@@ -173,16 +175,74 @@ yarn start
 ```
 
 ### Demo
+
 The demo is a [Create React App](https://create-react-app.dev/) boilerplate with `react-icons` added as a dependency for easy testing.
 
-```bash
-cd packages/react-icons
-yarn build
+### How to add an icon set
 
-cd ../demo
-yarn start
+#### 1. Add new git submodule
+
+From the main directory (where this file is located) run the following command:
+
+```bash
+git submodule add --name <name> <git-repo-url-for-the-new-icon-set> packages/react-icons/src/icons/<name>
 ```
 
+#### 2. Modify **README.md** (this document)
+
+Add the name, URL, and the license link to the table in the `##Icons` section of this file.
+Keep the list in alphabetical order.
+
+#### 3. Modify **packages/react-icons/.gitignore**
+
+Add the two-letter folder name for the new icon set, e.g.:
+
+```text
+...
+/xy/
+...
+```
+
+#### 4. Modify **packages/react-icons/LICENSE**
+
+Add license details about the new icon set.
+
+#### 5. Modify **packages/react-icons/src/icons/index.js**
+
+Add the object with the following structure:
+
+```JavaScript
+{
+      id: "xy",                                    // Two-letter id
+      name: "e.g. Xenon Yellow Icons",             // The full icon set name
+      contents: [
+        {
+          files: path.resolve(__dirname, "<relative-path-to-git-submodule>/<path-to-svg-icons>/<filter>"),
+          formatter: name => `Xy${name}`            // So that all icon names from this set will start with "Xy"
+        }
+      ],
+      // URL of the github repo
+      projectUrl: "https://github.com/xy/xy-icons",
+      license: "Apache License Version 2.0",        // License type
+      licenseUrl: "http://www.apache.org/licenses/" // URL of the license definition
+}
+```
+
+to the `icons` array.
+
+#### 6. Once everything builds and looks right in the preview, create a pull request
+
+## Tips
+
+### SVG
+
+Svg is [supported](http://caniuse.com/#search=svg) by all major browsers.
+
+### Why ES6 import and not fonts
+
+With `react-icons`, you can serve only the needed icons instead of one big font file to the users, helping you to recognize which icons are used in your project.
+
+### Related
 ## Why React SVG components instead of fonts?
 
 SVG is [supported by all major browsers](http://caniuse.com/#search=svg). With `react-icons`, you can serve only the needed icons instead of one big font file to the users, helping you to recognize which icons are used in your project.

--- a/packages/react-icons/.gitignore
+++ b/packages/react-icons/.gitignore
@@ -16,5 +16,6 @@
 /ai/
 /bs/
 /ri/
+/px/
 README.md
 

--- a/packages/react-icons/LICENSE
+++ b/packages/react-icons/LICENSE
@@ -45,3 +45,6 @@ License: MIT https://opensource.org/licenses/MIT
 
 Remix Icon - https://github.com/Remix-Design/RemixIcon
 License: Apache License Version 2.0 http://www.apache.org/licenses/
+
+Predix Design System Icons - https://github.com/tromgy/px-icon-set
+License: Apache License Version 2.0 http://www.apache.org/licenses/

--- a/packages/react-icons/src/iconBase.tsx
+++ b/packages/react-icons/src/iconBase.tsx
@@ -6,15 +6,42 @@ export interface IconTree {
   tag: string;
   attr: {[key: string]: string};
   child: IconTree[];
+  content: string;
 }
-
 
 function Tree2Element(tree: IconTree[]): React.ReactElement<{}>[] {
-  return tree && tree.map((node, i) => React.createElement(node.tag, {key: i, ...node.attr}, Tree2Element(node.child)));
+  return tree && tree.map((node, i) => React.createElement(node.tag, {key: i, ...node.attr}, node.content, Tree2Element(node.child)));
 }
+
+function HasStrokes(svg: any) : boolean {
+  for (const prop in svg) {
+    if (prop[0] === '_') {
+      continue; // don't go into any "private" properties
+    }
+    if (prop === "stroke") {
+      return true;
+    } else if (typeof svg[prop] === "object") {
+      const result = HasStrokes(svg[prop]);
+      if (result) {
+        return result;
+      }
+    } else if (prop === "content") {
+      // check if this content is for the <style> tag
+      if (svg["tag"] === "style") {
+        // "content" may have styles for the stroke
+        if (svg[prop].includes("stroke:")) {
+          return true;
+        }
+      }
+    }
+  }
+
+  return false;
+}
+
 export function GenIcon(data: IconTree) {
   return (props: IconBaseProps) => (
-    <IconBase attr={{...data.attr}} {...props}>
+    <IconBase attr={{...data.attr}} {...props} hasStrokes={HasStrokes(data)}>
       {Tree2Element(data.child)}
     </IconBase>
   );
@@ -25,22 +52,27 @@ export interface IconBaseProps extends React.SVGAttributes<SVGElement> {
   size?: string | number;
   color?: string;
   title?: string;
+  hasStrokes?: boolean;
 }
 
 export type IconType = (props: IconBaseProps) => JSX.Element;
+
 export function IconBase(props:IconBaseProps & { attr: {} | undefined }): JSX.Element {
   const elem = (conf: IconContext) => {
     const computedSize = props.size || conf.size || "1em";
     let className;
     if (conf.className) className = conf.className;
     if (props.className) className = (className ? className + ' ' : '') + props.className;
-    const {attr, title, ...svgProps} = props;
+    const {attr, title, hasStrokes, ...svgProps} = props;
+
+    // If the icon has explicit "stroke" attribute, do NOT set zero stroke width
+    const stroke =  hasStrokes? null : { strokeWidth: 0 };
 
     return (
       <svg
         stroke="currentColor"
         fill="currentColor"
-        strokeWidth="0"
+        {...stroke} 
         {...conf.attr}
         {...attr}
         {...svgProps}

--- a/packages/react-icons/src/icons/index.js
+++ b/packages/react-icons/src/icons/index.js
@@ -267,6 +267,21 @@ module.exports = {
       projectUrl: "https://github.com/Remix-Design/RemixIcon",
       license: "Apache License Version 2.0",
       licenseUrl: "http://www.apache.org/licenses/"
+    },
+    {
+      id: "px",
+      name: "Predix Design System Icons",
+      contents: [
+        {
+          files: path.resolve(__dirname, "px-icon-set/icons/src-*/*.svg"),
+          formatter: name => `Px${name}`
+        }
+      ],
+      // use this repo for the time being, the official one doesn't seem to be
+      // maintaned anymore
+      projectUrl: "https://github.com/tromgy/px-icon-set",
+      license: "Apache License Version 2.0",
+      licenseUrl: "http://www.apache.org/licenses/"
     }
   ]
 };


### PR DESCRIPTION
This is part 2 of [the older PR](https://github.com/react-icons/react-icons/pull/284)

Here's what this pull request tries to accomplish:

- Add support for SVGs with: inline styles, internal CSS, stroke presentation attributes, and `<text>`
- Add Predix Design System icons
- Document how to add icons in README.md