### PR TITLE
Add Boxicons variants: solid and logos

### DIFF
--- a/packages/react-icons/VERSIONS
+++ b/packages/react-icons/VERSIONS
@@ -22,3 +22,5 @@ Icon Library|License|Version|Count
 [BoxIcons](https://github.com/atisawd/boxicons)|[CC BY 4.0 License](undefined)|2.0.5|738
 [css.gg](https://github.com/astrit/css.gg)|[MIT](https://opensource.org/licenses/MIT)|2.0.0|704
 [VS Code Icons](https://github.com/microsoft/vscode-codicons)|[CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)|0.0.1|319
+[BoxIcons Solid](https://github.com/atisawd/boxicons)|[CC BY 4.0 License](undefined)|2.0.5|611
+[BoxIcons Logos](https://github.com/atisawd/boxicons)|[CC BY 4.0 License](undefined)|2.0.5|113

--- a/packages/react-icons/src/icons/index.js
+++ b/packages/react-icons/src/icons/index.js
@@ -340,5 +340,29 @@ module.exports = {
       license: "CC BY 4.0",
       licenseUrl: "https://creativecommons.org/licenses/by/4.0/",
     },
+    {
+      id: "bis",
+      name: "BoxIcons Solid",
+      contents: [
+        {
+          files: path.resolve(__dirname, "boxicons/svg/solid/*.svg"),
+          formatter: (name) => `Bis${name.replace("Bxs", "")}`,
+        },
+      ],
+      projectUrl: "https://github.com/atisawd/boxicons",
+      license: "CC BY 4.0 License",
+    },
+    {
+      id: "bil",
+      name: "BoxIcons Logos",
+      contents: [
+        {
+          files: path.resolve(__dirname, "boxicons/svg/logos/*.svg"),
+          formatter: (name) => `Bil${name.replace("Bxl", "")}`,
+        },
+      ],
+      projectUrl: "https://github.com/atisawd/boxicons",
+      license: "CC BY 4.0 License",
+    },
   ],
 };


### PR DESCRIPTION
Currently only regular variant of **Boxicons** is included in the repo, while its docs mention also _Solid_ and _Logos_. 
Since choosing variants by attributes is not supported as in the docs, this PR includes two other variants of this iconset. 