### PR TITLE
ADD: themify icons

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -49,3 +49,6 @@
 [submodule "vscode-icons"]
 	path = packages/react-icons/src/icons/vscode-icons
 	url = https://github.com/microsoft/vscode-codicons.git
+[submodule "packages/react-icons/src/icons/themify-icons"]
+	path = packages/react-icons/src/icons/themify-icons
+	url = https://github.com/lykmapipo/themify-icons.git

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Icon Library|License|Version|Count
 [BoxIcons](https://github.com/atisawd/boxicons)|[CC BY 4.0 License](undefined)|2.0.5|738
 [css.gg](https://github.com/astrit/css.gg)|[MIT](https://opensource.org/licenses/MIT)|2.0.0|704
 [VS Code Icons](https://github.com/microsoft/vscode-codicons)|[CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)|0.0.1|319
+[Themify Icons](https://github.com/lykmapipo/themify-icons)|[MIT](https://github.com/thecreation/standard-icons/blob/master/modules/themify-icons/LICENSE)|1.0.1|352
 
 
 You can add more icons by submitting pull requests or creating issues.

--- a/packages/react-icons/VERSIONS
+++ b/packages/react-icons/VERSIONS
@@ -22,3 +22,5 @@ Icon Library|License|Version|Count
 [BoxIcons](https://github.com/atisawd/boxicons)|[CC BY 4.0 License](undefined)|2.0.5|738
 [css.gg](https://github.com/astrit/css.gg)|[MIT](https://opensource.org/licenses/MIT)|2.0.0|704
 [VS Code Icons](https://github.com/microsoft/vscode-codicons)|[CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)|0.0.1|319
+[Themify-Icons](https://github.com/lykmapipo/themify-icons)|[MIT](https://github.com/thecreation/standard-icons/blob/master/modules/themify-icons/LICENSE)|v0.1.2
+ad5ed84802fea2b865ce07220435a3a16b266837|352

--- a/packages/react-icons/src/icons/index.js
+++ b/packages/react-icons/src/icons/index.js
@@ -340,5 +340,19 @@ module.exports = {
       license: "CC BY 4.0",
       licenseUrl: "https://creativecommons.org/licenses/by/4.0/",
     },
+    {
+      id: "tfi",
+      name: "Themify Icons",
+      contents: [
+        {
+          files: path.resolve(__dirname, "themify-icons/SVG/*.svg"),
+          formatter: (name) => `Tfi${name}`,
+        },
+      ],
+      projectUrl: "https://github.com/lykmapipo/themify-icons",
+      license: "MIT",
+      licenseUrl:
+        "https://github.com/thecreation/standard-icons/blob/master/modules/themify-icons/LICENSE",
+    },
   ],
 };


### PR DESCRIPTION
This PR adds the themify icons - Closes #245

Usage
`import { TfiAgenda } from "react-icons/tfi";`

[Themify icons homepage](http://themify.me/themify-icons)

[Themify icons repository](https://github.com/lykmapipo/themify-icons)

