### PR TITLE
Include Remix Icons without fill/line suffix

### DIFF
--- a/packages/react-icons/src/icons/index.js
+++ b/packages/react-icons/src/icons/index.js
@@ -221,15 +221,7 @@ module.exports = {
       name: "Remix Icon",
       contents: [
         {
-          files: path.resolve(__dirname, "RemixIcon/icons/*/*!(-fill|-line).svg"),
-          formatter: (name) => `Ri${name}`,
-        },
-        {
-          files: path.resolve(__dirname, "RemixIcon/icons/*/*-line.svg"),
-          formatter: (name) => `Ri${name}`,
-        },
-        {
-          files: path.resolve(__dirname, "RemixIcon/icons/*/*-fill.svg"),
+          files: path.resolve(__dirname, "RemixIcon/icons/*/*.svg"),
           formatter: (name) => `Ri${name}`,
         },
       ],

--- a/packages/react-icons/src/icons/index.js
+++ b/packages/react-icons/src/icons/index.js
@@ -221,6 +221,10 @@ module.exports = {
       name: "Remix Icon",
       contents: [
         {
+          files: path.resolve(__dirname, "RemixIcon/icons/*/*!(-fill|-line).svg"),
+          formatter: (name) => `Ri${name}`,
+        },
+        {
           files: path.resolve(__dirname, "RemixIcon/icons/*/*-line.svg"),
           formatter: (name) => `Ri${name}`,
         },


### PR DESCRIPTION
Some remix icons don't suffix with `line` or `fill`, like all of those in [Editor](https://remixicon.com/#edito) category ([git link](https://github.com/Remix-Design/RemixIcon/tree/master/icons/Editor)). As a result, they're currently omitted from `react-icons` 