### PR TITLE
Upgrade Material Design Icons to 4.0.0

### DIFF
--- a/packages/react-icons/VERSIONS
+++ b/packages/react-icons/VERSIONS
@@ -5,7 +5,7 @@ Icon Library|License|Version|Count
 [Ionicons 4](https://ionicons.com/)|[MIT](https://github.com/ionic-team/ionicons/blob/master/LICENSE)|4.6.3|696
 [Ionicons 5](https://ionicons.com/)|[MIT](https://github.com/ionic-team/ionicons/blob/master/LICENSE)|5.2.3|1300
 [Material Design icons](http://google.github.io/material-design-icons/)|[Apache License Version 2.0](https://github.com/google/material-design-icons/blob/master/LICENSE)|4.0.0
-b3f05bfbf4329a5b63f50a720f867c2bac163f98|1503
+b3f05bfbf4329a5b63f50a720f867c2bac163f98|1546
 [Typicons](http://s-ings.com/typicons/)|[CC BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/)|2.0.9|336
 [Github Octicons icons](https://octicons.github.com/)|[MIT](https://github.com/primer/octicons/blob/master/LICENSE)|8.5.0|184
 [Feather](https://feathericons.com/)|[MIT](https://github.com/feathericons/feather/blob/master/LICENSE)|4.28.0|286

--- a/packages/react-icons/VERSIONS
+++ b/packages/react-icons/VERSIONS
@@ -4,7 +4,8 @@ Icon Library|License|Version|Count
 0d1f27efb836eb2ab994ba37221849ed64a73e5c|1560
 [Ionicons 4](https://ionicons.com/)|[MIT](https://github.com/ionic-team/ionicons/blob/master/LICENSE)|4.6.3|696
 [Ionicons 5](https://ionicons.com/)|[MIT](https://github.com/ionic-team/ionicons/blob/master/LICENSE)|5.2.3|1300
-[Material Design icons](http://google.github.io/material-design-icons/)|[Apache License Version 2.0](https://github.com/google/material-design-icons/blob/master/LICENSE)|3.0.1|960
+[Material Design icons](http://google.github.io/material-design-icons/)|[Apache License Version 2.0](https://github.com/google/material-design-icons/blob/master/LICENSE)|4.0.0
+b3f05bfbf4329a5b63f50a720f867c2bac163f98|1503
 [Typicons](http://s-ings.com/typicons/)|[CC BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/)|2.0.9|336
 [Github Octicons icons](https://octicons.github.com/)|[MIT](https://github.com/primer/octicons/blob/master/LICENSE)|8.5.0|184
 [Feather](https://feathericons.com/)|[MIT](https://github.com/feathericons/feather/blob/master/LICENSE)|4.28.0|286

--- a/packages/react-icons/scripts/logics.js
+++ b/packages/react-icons/scripts/logics.js
@@ -5,7 +5,9 @@ const fs = require("fs").promises;
 const path = require("path");
 
 async function getIconFiles(content) {
-  return glob(content.files);
+  return typeof content.files === "function"
+    ? await content.files()
+    : glob(content.files);
 }
 async function convertIconData(svg, multiColor) {
   const $svg = cheerio.load(svg, { xmlMode: true })("svg");

--- a/packages/react-icons/scripts/task_all.js
+++ b/packages/react-icons/scripts/task_all.js
@@ -84,7 +84,8 @@ async function writeIconModule(icon, { DIST, LIB, rootDir }) {
       const rawName = path.basename(file, path.extname(file));
       const pascalName = camelcase(rawName, { pascalCase: true });
       const name =
-        (content.formatter && content.formatter(pascalName)) || pascalName;
+        (content.formatter && content.formatter(pascalName, file)) ||
+        pascalName;
       if (exists.has(name)) continue;
       exists.add(name);
 

--- a/packages/react-icons/scripts/task_files.js
+++ b/packages/react-icons/scripts/task_files.js
@@ -53,7 +53,8 @@ async function writeIconModuleFiles(icon, { DIST, LIB, rootDir }) {
       const rawName = path.basename(file, path.extname(file));
       const pascalName = camelcase(rawName, { pascalCase: true });
       const name =
-        (content.formatter && content.formatter(pascalName)) || pascalName;
+        (content.formatter && content.formatter(pascalName, file)) ||
+        pascalName;
       if (exists.has(name)) continue;
       exists.add(name);
 

--- a/packages/react-icons/src/icons/index.js
+++ b/packages/react-icons/src/icons/index.js
@@ -1,4 +1,5 @@
 const path = require("path");
+const camelcase = require("camelcase");
 
 module.exports = {
   icons: [
@@ -62,9 +63,14 @@ module.exports = {
         {
           files: path.resolve(
             __dirname,
-            "material-design-icons/*/svg/production/*_24px.svg"
+            "material-design-icons/src/*/*/materialicons/24px.svg"
           ),
-          formatter: (name) => name.replace(/Ic(\w+)24px/i, "Md$1"),
+          formatter: (name, file) =>
+            `Md${camelcase(
+              file.replace(/^.*\/([^/]+)\/materialicons\/24px.svg$/i, "$1"),
+              { pascalCase: true }
+            )}`,
+          processWithSVGO: true,
         },
       ],
       projectUrl: "http://google.github.io/material-design-icons/",

--- a/packages/react-icons/src/icons/index.js
+++ b/packages/react-icons/src/icons/index.js
@@ -1,5 +1,6 @@
 const path = require("path");
 const camelcase = require("camelcase");
+const glob = require("glob-promise");
 
 module.exports = {
   icons: [
@@ -61,13 +62,32 @@ module.exports = {
       name: "Material Design icons",
       contents: [
         {
-          files: path.resolve(
-            __dirname,
-            "material-design-icons/src/*/*/materialicons/24px.svg"
-          ),
+          files: async () => {
+            const normal = await glob(
+              path.resolve(
+                __dirname,
+                "material-design-icons/src/*/*/materialicons/24px.svg"
+              )
+            );
+            const twotone = await glob(
+              path.resolve(
+                __dirname,
+                "material-design-icons/src/*/*/materialiconstwotone/24px.svg"
+              )
+            );
+            return [
+              ...normal,
+              ...twotone.filter(
+                (file) => !normal.includes(file.replace("twotone/", "/"))
+              ),
+            ];
+          },
           formatter: (name, file) =>
             `Md${camelcase(
-              file.replace(/^.*\/([^/]+)\/materialicons\/24px.svg$/i, "$1"),
+              file.replace(
+                /^.*\/([^/]+)\/materialicons[^/]*\/24px.svg$/i,
+                "$1"
+              ),
               { pascalCase: true }
             )}`,
           processWithSVGO: true,


### PR DESCRIPTION
This upgrade required adding a few features to the build scripts to support the new file structure. The only *breaking* change is that the `MdMotorcycle` icon has been removed upstream. They've added `MdTwoWheeler` though, which is a decent replacement. Maybe alias that to `MdMotorcycle` if you didn't want breaking changes in a future release.

I'm opening this PR without the submodule update, since GitHub is choking on that right now. I'll push that momentarily.