### PR TITLE
change copy complete ES6 Version

### DIFF
--- a/packages/preview/src/components/@core/icon/index.tsx
+++ b/packages/preview/src/components/@core/icon/index.tsx
@@ -8,7 +8,7 @@ function Icon({ icon, name, highlightPattern = null }) {
     const iconType = name.match(pattern);
 
     const copyToClipboardValue = `import { ${name} } from "react-icons/${iconType[0].toLowerCase()}"`;
-    console.log(copyToClipboardValue);
+    // console.log(copyToClipboardValue);
     copy(copyToClipboardValue);
 
     toast.success(`Copied '${name}' to clipboard`, {

--- a/packages/preview/src/components/@core/icon/index.tsx
+++ b/packages/preview/src/components/@core/icon/index.tsx
@@ -4,9 +4,15 @@ import React from "react";
 
 function Icon({ icon, name, highlightPattern = null }) {
   const copyToClipboard = () => {
-    copy(name);
+    const pattern = /[A-Z][a-z]{1,3}/g;
+    const iconType = name.match(pattern);
+
+    const copyToClipboardValue = `import { ${name} } from "react-icons/${iconType[0].toLowerCase()}"`;
+    console.log(copyToClipboardValue);
+    copy(copyToClipboardValue);
+
     toast.success(`Copied '${name}' to clipboard`, {
-      position: "bottom-center"
+      position: "bottom-center",
     });
   };
 


### PR DESCRIPTION
This PRs change copy complete ES6 Version  [https://github.com/react-icons/react-icons/issues/412](https://github.com/react-icons/react-icons/issues/412)

Example
If you press the button to copy
Before  `BiAbacus`
To
After `import { BiAbacus } from "react-icons/bi`
