### PR TITLE
feat: add "/" hotkey to focus search input

### DIFF
--- a/packages/preview/src/components/@core/sidebar/index.tsx
+++ b/packages/preview/src/components/@core/sidebar/index.tsx
@@ -1,7 +1,7 @@
 import { ALL_ICONS } from "@utils/icon";
 import { Context } from "@utils/search-context";
 import { useRouter } from "next/router";
-import React, { useState } from "react";
+import React, { useState, useEffect, useRef } from "react";
 
 import ActiveLink from "../active-link";
 import Heading from "../heading";
@@ -15,6 +15,19 @@ export default function Sidebar() {
   const [inputQuery, setInputQuery] = useState(null);
 
   const { query, setQuery, setResults } = React.useContext(Context);
+
+  const searchInputRef = useRef(null);
+  const focusSearchInput = ({ key }) => {
+    if (searchInputRef.current && key === "/") {
+      searchInputRef.current.focus();
+    }
+  };
+  useEffect(() => {
+    document.addEventListener("keydown", focusSearchInput);
+    return () => {
+      document.removeEventListener("keydown", focusSearchInput, true);
+    };
+  }, []);
 
   const setQueryEveywhere = (query) => {
     setQuery(query); // Context
@@ -46,10 +59,11 @@ export default function Sidebar() {
 
       <div className="search p2">
         <input
+          ref={searchInputRef}
           type="text"
           aria-label="search"
           className="px2 py1"
-          placeholder="🔍 Search Icons"
+          placeholder="🔍 Search Icons (/)"
           onFocus={goToSearch}
           onBlur={onBlur}
           onChange={onSearch}


### PR DESCRIPTION
I use the search feature a lot and I've to play a game of <kbd>tab</kbd> to get to it after the page loads (without using the mouse  cause I'm too lazy to reach there).

Just a minor improvement from my side! 
Thanks!

P.S. I haven't tested it as I was getting installation errors.