### PR TITLE
Add `solid` and `logos` variants of Boxicons

### DIFF
--- a/packages/react-icons/src/icons/index.js
+++ b/packages/react-icons/src/icons/index.js
@@ -306,6 +306,14 @@ module.exports = {
           files: path.resolve(__dirname, "boxicons/svg/regular/*.svg"),
           formatter: (name) => `Bi${name.replace("Bx", "")}`,
         },
+        {
+          files: path.resolve(__dirname, "boxicons/svg/solid/*.svg"),
+          formatter: (name) => `BiSolid${name.replace("Bxs", "")}`,
+        },
+        {
+          files: path.resolve(__dirname, "boxicons/svg/logos/*.svg"),
+          formatter: (name) => `BiLogos${name.replace("Bxl", "")}`,
+        },
       ],
       projectUrl: "https://github.com/atisawd/boxicons",
       license: "CC BY 4.0 License",


### PR DESCRIPTION
Due to inactivity of https://github.com/react-icons/react-icons/pull/393 I created a separate PR to align the new variants with the naming convention.

Hope that’s fine for you! ✌️