### PR TITLE
Avoid auto correction and spell checks

### DIFF
--- a/packages/preview/src/components/@core/sidebar/index.tsx
+++ b/packages/preview/src/components/@core/sidebar/index.tsx
@@ -54,6 +54,7 @@ export default function Sidebar() {
           onBlur={onBlur}
           onChange={onSearch}
           value={inputQuery !== null ? inputQuery : query}
+          autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"
         />
       </div>
 


### PR DESCRIPTION
# Summary
It might be worth while, but adding some input attributes that would prevent spell checks and auto corrections.

# Experience
When using the search field I found it difficult to quickly search and sort when my queries were auto-corrected. Neither are super helpful or this use case and it may improve the experience forcing them not to check and/or correct.

# Suggestion
 I realize this behavior is different on every machine and user. Applying these fixed attributes would help make that behavior between users and environments more consistent.