### PR TITLE
Fix syntax highlighting for shell/bash code blocks

### DIFF
--- a/packages/preview/src/components/@core/code-block/index.tsx
+++ b/packages/preview/src/components/@core/code-block/index.tsx
@@ -5,7 +5,7 @@ import PrismTheme from "prism-react-renderer/themes/nightOwl";
 import React from "react";
 import { IoMdClipboard } from "react-icons/io";
 
-export default function CodeBlock({ code }) {
+export default function CodeBlock({ code, language }) {
   const copyToClipboard = () => {
     copy(code);
     toast.success(`Copied to clipboard`, {
@@ -18,7 +18,7 @@ export default function CodeBlock({ code }) {
       {...defaultProps}
       theme={PrismTheme}
       code={code.trim()}
-      language="jsx"
+      language={language}
     >
       {({ className, style, tokens, getLineProps, getTokenProps }) => (
         <pre className={`${className} code`} style={style}>

--- a/packages/preview/src/components/pages/icons/iconset-import.tsx
+++ b/packages/preview/src/components/pages/icons/iconset-import.tsx
@@ -7,7 +7,7 @@ export default function IconSetImport({ iconId }) {
   return (
     <>
       <h2>Import</h2>
-      <CodeBlock code={importCode} />
+      <CodeBlock language="jsx" code={importCode} />
     </>
   );
 }

--- a/packages/preview/src/pages/index.tsx
+++ b/packages/preview/src/pages/index.tsx
@@ -15,10 +15,10 @@ export default function HomePage() {
       </p>
 
       <h2>Installation (for standard modern project)</h2>
-      <CodeBlock code={`npm install react-icons --save`} />
+      <CodeBlock language="bash" code={`npm install react-icons --save`} />
 
       <h3>Usage</h3>
-      <CodeBlock code={HOME_USAGE} />
+      <CodeBlock language="jsx" code={HOME_USAGE} />
 
       <h2>Installation (for meteorjs, gatsbyjs, etc)</h2>
       <p>
@@ -26,10 +26,10 @@ export default function HomePage() {
         This method has the trade-off that it takes a long time to install the package.
         Suitable for MeteorJS, Gatsbyjs etc.
       </p>
-      <CodeBlock code={`npm install @react-icons/all-files --save`} />
+      <CodeBlock language="bash" code={`npm install @react-icons/all-files --save`} />
       
       <h3>Usage</h3>
-      <CodeBlock code={HOME_USAGE_ALL} />
+      <CodeBlock language="jsx" code={HOME_USAGE_ALL} />
 
       <h2>More info</h2>
       <p>


### PR DESCRIPTION
On the `react-icons` preview website (https://react-icons.github.io/react-icons/) the home page code blocks for containing `npm install react-icons --save` and `npm install @react-icons/all-files --save` are highlighted using a jsx syntax highlighter instead of shell/bash. 

**Current Highlighting**
<img width="658" alt="Installation (for standard modern project)" src="https://user-images.githubusercontent.com/55829590/128306240-d05439c9-a2aa-44fe-adb2-71e3854412a7.png">
<img width="658" alt="Installation (for meteorjs, gatsbyjs, etc)" src="https://user-images.githubusercontent.com/55829590/128306252-bf32622a-ac04-45ad-bee8-d52301fdc699.png">

**Proposed Highlighting**
![Installation (for meteorjs, gatsbyjs, etc) bash](https://user-images.githubusercontent.com/55829590/128306401-cb2ee74f-6070-4fbc-b2d7-1d109a2e8c16.png)
![Installation (for standard modern project) bash](https://user-images.githubusercontent.com/55829590/128306413-2bee8b7e-3b4b-46ca-b398-369f2f7bd0d6.png)
