### PR TITLE
Add Tabler icons

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -49,3 +49,6 @@
 [submodule "vscode-icons"]
 	path = packages/react-icons/src/icons/vscode-icons
 	url = https://github.com/microsoft/vscode-codicons.git
+[submodule "packages/react-icons/src/icons/tabler-icons"]
+	path = packages/react-icons/src/icons/tabler-icons
+	url = https://github.com/tabler/tabler-icons

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Icon Library|License|Version|Count
 [BoxIcons](https://github.com/atisawd/boxicons)|[CC BY 4.0 License](undefined)|2.0.9|757
 [css.gg](https://github.com/astrit/css.gg)|[MIT](https://opensource.org/licenses/MIT)|2.0.0|704
 [VS Code Icons](https://github.com/microsoft/vscode-codicons)|[CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)|0.0.23|383
+[Tabler Icons](https://github.com/tabler/tabler-icons)|[MIT](https://opensource.org/licenses/MIT)|1.68.0|1978
 
 
 You can add more icons by submitting pull requests or creating issues.

--- a/packages/react-icons/VERSIONS
+++ b/packages/react-icons/VERSIONS
@@ -23,3 +23,4 @@ Icon Library|License|Version|Count
 [BoxIcons](https://github.com/atisawd/boxicons)|[CC BY 4.0 License](undefined)|2.0.9|757
 [css.gg](https://github.com/astrit/css.gg)|[MIT](https://opensource.org/licenses/MIT)|2.0.0|704
 [VS Code Icons](https://github.com/microsoft/vscode-codicons)|[CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)|0.0.23|383
+[Tabler Icons](https://github.com/tabler/tabler-icons)|[MIT](https://opensource.org/licenses/MIT)|1.68.0|1978

--- a/packages/react-icons/src/icons/index.js
+++ b/packages/react-icons/src/icons/index.js
@@ -378,5 +378,18 @@ module.exports = {
       license: "CC BY 4.0",
       licenseUrl: "https://creativecommons.org/licenses/by/4.0/",
     },
+    {
+      id: "tb",
+      name: "Tabler Icons",
+      contents: [
+        {
+          files: path.resolve(__dirname, "tabler-icons/icons/*.svg"),
+          formatter: (name) => `Tb${name}`,
+        },
+      ],
+      projectUrl: "https://github.com/tabler/tabler-icons",
+      license: "MIT",
+      licenseUrl: "https://opensource.org/licenses/MIT",
+    },
   ],
 };


### PR DESCRIPTION
[Tabler icons](https://github.com/tabler/tabler-icons) is one of the popular icon packs having stars more than 11k.

- **Icon count:** 1978
- **License:** [MIT](https://opensource.org/licenses/MIT)

Close #558.

![image](https://user-images.githubusercontent.com/45073703/170823022-32ac60ea-bb82-492b-84dd-cbe93418f285.png)