### PR TITLE
fixed IconContext not having the prop: 'title'

### DIFF
--- a/packages/react-icons/src/iconContext.tsx
+++ b/packages/react-icons/src/iconContext.tsx
@@ -6,8 +6,7 @@ export interface IconContext {
   className?: string;
   style?: React.CSSProperties;
   attr?: React.SVGAttributes<SVGElement>;
-  title?: string
-
+  title?: string;
 }
 
 export const DefaultContext: IconContext = {

--- a/packages/react-icons/src/iconContext.tsx
+++ b/packages/react-icons/src/iconContext.tsx
@@ -6,6 +6,8 @@ export interface IconContext {
   className?: string;
   style?: React.CSSProperties;
   attr?: React.SVGAttributes<SVGElement>;
+  title?: string
+
 }
 
 export const DefaultContext: IconContext = {
@@ -14,6 +16,7 @@ export const DefaultContext: IconContext = {
   className: undefined,
   style: undefined,
   attr: undefined,
+  title: undefined
 };
 
 export const IconContext: React.Context<IconContext> = React.createContext && React.createContext(DefaultContext);


### PR DESCRIPTION
According to the [docs](https://github.com/react-icons/react-icons#configuration), the IconContext is supposed to include the property 'title' for accessibility, however it was not included in the type of the context nor was it included in the object passed to createContext for initialization (Refer to #587).

