### PR TITLE
Add Heroicons mini

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ module
 *.log
 *.tgz
 
+.idea
+
 .pnp.*
 .yarn/*
 !.yarn/patches

--- a/packages/react-icons/VERSIONS
+++ b/packages/react-icons/VERSIONS
@@ -17,7 +17,7 @@
 | [Flat Color Icons](https://github.com/icons8/flat-color-icons) | [MIT](https://opensource.org/licenses/MIT) | 1.0.2 | 329 |
 | [Grommet-Icons](https://github.com/grommet/grommet-icons) | [Apache License Version 2.0](http://www.apache.org/licenses/) | 4.9.0 | 620 |
 | [Heroicons](https://github.com/tailwindlabs/heroicons) | [MIT](https://opensource.org/licenses/MIT) | 1.0.6 | 460 |
-| [Heroicons 2](https://github.com/tailwindlabs/heroicons) | [MIT](https://opensource.org/licenses/MIT) | 2.0.16 | 584 |
+| [Heroicons 2](https://github.com/tailwindlabs/heroicons) | [MIT](https://opensource.org/licenses/MIT) | 2.0.17 | 876 |
 | [Simple Icons](https://simpleicons.org/) | [CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/) | 8.6.0 | 2437 |
 | [Simple Line Icons](https://thesabbir.github.io/simple-line-icons/) | [MIT](https://opensource.org/licenses/MIT) | 2.5.5 | 189 |
 | [IcoMoon Free](https://github.com/Keyamoon/IcoMoon-Free) | [CC BY 4.0 License](https://github.com/Keyamoon/IcoMoon-Free/blob/master/License.txt) | d006795ede82361e1bac1ee76f215cf1dc51e4ca | 491 |

--- a/packages/react-icons/src/icons/index.ts
+++ b/packages/react-icons/src/icons/index.ts
@@ -480,7 +480,7 @@ export const icons: IconDefinition[] = [
       remoteDir: "optimized/",
       url: "https://github.com/tailwindlabs/heroicons.git",
       branch: "master",
-      hash: "1ef549d0b7eaba7224b3db9654894fad12364f7f",
+      hash: "857ba1b04f8017a36c7c0fd6e2738fef37492f18",
     },
   },
   {

--- a/packages/react-icons/src/icons/index.ts
+++ b/packages/react-icons/src/icons/index.ts
@@ -432,13 +432,6 @@ export const icons: IconDefinition[] = [
         ),
         formatter: (name) => `HiOutline${name}`,
       },
-      {
-        files: path.resolve(
-          __dirname,
-          "heroicons-2/optimized/20/solid/*.svg"
-        ),
-        formatter: (name) => `HiMini${name}`,
-      },
     ],
     projectUrl: "https://github.com/tailwindlabs/heroicons",
     license: "MIT",
@@ -469,6 +462,13 @@ export const icons: IconDefinition[] = [
           "../../icons/heroicons-2/optimized/24/outline/*.svg"
         ),
         formatter: (name) => `HiOutline${name}`,
+      },
+      {
+        files: path.resolve(
+          __dirname,
+          "../../icons/heroicons-2/optimized/20/solid/*.svg"
+        ),
+        formatter: (name) => `HiMini${name}`,
       },
     ],
     projectUrl: "https://github.com/tailwindlabs/heroicons",

--- a/packages/react-icons/src/icons/index.ts
+++ b/packages/react-icons/src/icons/index.ts
@@ -432,6 +432,13 @@ export const icons: IconDefinition[] = [
         ),
         formatter: (name) => `HiOutline${name}`,
       },
+      {
+        files: path.resolve(
+          __dirname,
+          "heroicons-2/optimized/20/solid/*.svg"
+        ),
+        formatter: (name) => `HiMini${name}`,
+      },
     ],
     projectUrl: "https://github.com/tailwindlabs/heroicons",
     license: "MIT",


### PR DESCRIPTION
This PR adds the mini version of the 2nd version of Heroicons, according to https://github.com/react-icons/react-icons/pull/590#issuecomment-1245519004 they don't look the same as the solid ones.

@nolanleung can you please take a look? thanks :smile: 