### PR TITLE
open the link in a new tab

### DIFF
--- a/packages/preview/src/pages/index.tsx
+++ b/packages/preview/src/pages/index.tsx
@@ -33,7 +33,7 @@ export default function HomePage() {
 
       <h2>More info</h2>
       <p>
-        <a href="https://github.com/react-icons/react-icons">GitHub &#8599;</a>
+        <a href="https://github.com/react-icons/react-icons" target="_blank" rel="noopener">GitHub &#8599;</a>
       </p>
     </Container>
   );


### PR DESCRIPTION
this pr is to change how open the link pointing to github repo in a new tab without closing the react icon tab