### PR TITLE
Add Phosphor icons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ module
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+
+.idea/*

--- a/packages/react-icons/VERSIONS
+++ b/packages/react-icons/VERSIONS
@@ -27,3 +27,4 @@
 | [Tabler Icons](https://github.com/tabler/tabler-icons) | [MIT](https://opensource.org/licenses/MIT) | 2.7.0 | 3455 |
 | [Themify Icons](https://github.com/lykmapipo/themify-icons) | [MIT](https://github.com/thecreation/standard-icons/blob/master/modules/themify-icons/LICENSE) | v0.1.2-2-g9600186 | 352 |
 | [Radix Icons](https://icons.radix-ui.com) | [MIT](https://github.com/radix-ui/icons/blob/master/LICENSE) | @modulz/generate-icon-lib@0.2.1 | 318 |
+| [Phosphor Icons](https://github.com/phosphor-icons/core) | [MIT](https://github.com/phosphor-icons/core/blob/main/LICENSE) | 2.0.2 | 7488 |

--- a/packages/react-icons/src/icons/index.ts
+++ b/packages/react-icons/src/icons/index.ts
@@ -679,4 +679,28 @@ export const icons: IconDefinition[] = [
       hash: "4b9cdf66bc2a020113614bffa3dc9e61cf2738f1",
     },
   },
+  {
+    id: "pi",
+    name: "Phosphor Icons",
+    contents: [
+      {
+        files: path.resolve(
+          __dirname,
+          "../../icons/phosphor-icons/assets/*/*.svg"
+        ),
+        formatter: (name) => `Pi${name}`,
+      },
+    ],
+    projectUrl: "https://github.com/phosphor-icons/core",
+    license: "MIT",
+    licenseUrl: "https://github.com/phosphor-icons/core/blob/main/LICENSE",
+    source: {
+      type: "git",
+      localName: "phosphor-icons",
+      remoteDir: "assets/",
+      url: "https://github.com/phosphor-icons/core.git",
+      branch: "master",
+      hash: "ab1d712ad1278f3b159a0f24f127e66de6da17d7",
+    },
+  },
 ];


### PR DESCRIPTION
This PR adds the Phosphor icons using their react library which contains the necessary assets.
Closes #604 

cc: @kamijin-fanta 