### PR TITLE
Group icons by library name in search page

### DIFF
--- a/packages/preview-astro/src/components/search/search-iconset.tsx
+++ b/packages/preview-astro/src/components/search/search-iconset.tsx
@@ -39,6 +39,7 @@ export function SearchIconSet({
     );
   return (
     <>
+      {found.length > 0 && <h3 className="icon-name">{icon.name}</h3>}
       {found ? (
         found.map((name) => {
           const Component = icons[name];

--- a/packages/preview-astro/src/components/search/search-iconset.tsx
+++ b/packages/preview-astro/src/components/search/search-iconset.tsx
@@ -39,22 +39,24 @@ export function SearchIconSet({
     );
   return (
     <>
-      {found.length > 0 && <h3 className="icon-name">{icon.name}</h3>}
       {found ? (
-        found.map((name) => {
-          const Component = icons[name];
-          if (!Component) return null;
-          return (
-            <Icon
-              key={name}
-              component={Component}
-              iconSet={icon.id}
-              iconName={name}
-              highlightPattern={highlightPattern}
-              onSelect={(name) => onSelect?.(icon.id, name, Component)}
-            />
-          );
-        })
+        <>
+          {found.length > 0 && <h3 className="icon-name">{icon.name}</h3>}
+          {found.map((name) => {
+            const Component = icons[name];
+            if (!Component) return null;
+            return (
+              <Icon
+                key={name}
+                component={Component}
+                iconSet={icon.id}
+                iconName={name}
+                highlightPattern={highlightPattern}
+                onSelect={(name) => onSelect?.(icon.id, name, Component)}
+              />
+            );
+          })}
+        </>
       ) : (
         <SearchPageIconLoading />
       )}

--- a/packages/preview-astro/src/styles/_components.scss
+++ b/packages/preview-astro/src/styles/_components.scss
@@ -158,6 +158,12 @@ a {
   grid-row-gap: var(--space-2);
   text-align: center;
 
+  .icon-name {
+    margin-bottom: 0;
+    grid-column: 1 / -1;
+    text-align: left;
+  }
+
   .item {
     outline: none;
 


### PR DESCRIPTION
This PR adds the feature of grouping the icons by their library name in the search page

![image](https://user-images.githubusercontent.com/19949838/196548651-0e6fe62e-7ce1-4669-b944-6b40631b4fe8.png)
