### PR TITLE
Fix converting aria-* attribute names to camel case

### DIFF
--- a/packages/react-icons/scripts/logics.ts
+++ b/packages/react-icons/scripts/logics.ts
@@ -35,7 +35,7 @@ export async function convertIconData(svg, multiColor) {
           ].includes(name)
       )
       .reduce((obj, name) => {
-        const newName = camelcase(name);
+        const newName = name.startsWith("aria-") ? name : camelcase(name);
         switch (newName) {
           case "fill":
             if (


### PR DESCRIPTION
This PR fixes the new errors caused by hero icons 2 (`Invalid ARIA attribute ariaHidden. Did you mean aria-hidden.`) by non converting the `aria-*` attributes names to camel case.

cc: @kamijin-fanta 