### PR TITLE
Change versions table format

### DIFF
--- a/packages/react-icons/scripts/task_common.ts
+++ b/packages/react-icons/scripts/task_common.ts
@@ -128,16 +128,17 @@ export async function writeIconVersions({ DIST, LIB, rootDir }) {
   }
 
   const versionsStr =
-    "Icon Library|License|Version|Count\n" +
-    "---|---|---|---\n" +
+    "| Icon Library | License | Version | Count |\n" +
+    "| --- | --- | --- | ---: |\n" +
     versions
-      .map((v) =>
-        [
-          `[${v.icon.name}](${v.icon.projectUrl})`,
-          `[${v.icon.license}](${v.icon.licenseUrl})`,
-          v.version,
-          v.count,
-        ].join("|")
+      .map(
+        (v) =>
+          `| ${[
+            `[${v.icon.name}](${v.icon.projectUrl})`,
+            `[${v.icon.license}](${v.icon.licenseUrl})`,
+            v.version,
+            v.count,
+          ].join(" | ")} |`
       )
       .join("\n") +
     "\n";


### PR DESCRIPTION
The current VERSION file is shown well in the [release notes](https://github.com/react-icons/react-icons/releases/tag/v4.6.0), but [Renovate](https://www.mend.io/free-developer-tools/renovate/) in my repository could not show it well.

|[release notes](https://github.com/react-icons/react-icons/releases/tag/v4.6.0)|Renovate PR|
|-|-|
|![image](https://user-images.githubusercontent.com/7846521/196728042-398e7ff4-db50-45fc-8f83-9413ef655ced.png)|![image](https://user-images.githubusercontent.com/7846521/196728222-72fa7dc5-9a87-4601-9a24-5b2df0fcc437.png)|

So, I'll fix the format of table. 

