### PR TITLE
fix: escape query hightlight pattern

### DIFF
--- a/packages/preview/src/components/pages/search/index.tsx
+++ b/packages/preview/src/components/pages/search/index.tsx
@@ -10,7 +10,8 @@ export default function SearchPageComponent() {
   const { query } = React.useContext(Context);
 
   if (query.length > 2) {
-    const hightlightPattern = new RegExp(`(${query})`, "i");
+    const queryText = query.replace(/\W+/g, "");
+    const hightlightPattern = new RegExp(`(${queryText})`, "i");
     return (
       <>
         <h2>


### PR DESCRIPTION
Fix issue #633 by escaping query highlight text, so special characters will be ignored.