### PR TITLE
fix(logic-convertIconData): ignore camelCase in aria-* attributes

### DIFF
--- a/packages/react-icons/scripts/logics.ts
+++ b/packages/react-icons/scripts/logics.ts
@@ -35,7 +35,17 @@ export async function convertIconData(svg, multiColor) {
           ].includes(name)
       )
       .reduce((obj, name) => {
-        const newName = camelcase(name);
+        let newName: string;
+        if (new RegExp("aria-.*").test(name)) {
+          // https://reactjs.org/docs/accessibility.html#wai-aria
+          // Note that all aria-* HTML attributes are fully supported in JSX.
+          // Whereas most DOM properties and attributes in React are camelCased,
+          // these attributes should be hyphen-cased (also known as kebab-case, lisp-case, etc)
+          // as they are in plain HTML:
+          newName = name;
+        } else {
+          newName = camelcase(name);
+        }
         switch (newName) {
           case "fill":
             if (


### PR DESCRIPTION
This Invalid **ARIA attribute error** appears in the console when trying to use `heroicons@2`, this pull request aims to resolve this behavior by reacting as described in the documentation.
- [react-wai-aria](https://reactjs.org/docs/accessibility.html#wai-aria)
```console
Warning: Invalid ARIA attribute `ariaHidden`. Did you mean `aria-hidden`?
```
![image](https://user-images.githubusercontent.com/52186091/201445622-1b10425a-fbe8-46ea-a4b7-f1c812ef4dba.png)
![image](https://user-images.githubusercontent.com/52186091/201451498-b08b47ee-60da-4f0a-8e99-5c701c4d971c.png)

