### PR TITLE
Update Simple Icons to the last release (v8.5.0)

### DIFF
--- a/packages/react-icons/src/icons/index.ts
+++ b/packages/react-icons/src/icons/index.ts
@@ -494,7 +494,7 @@ export const icons: IconDefinition[] = [
       remoteDir: "icons/",
       url: "https://github.com/simple-icons/simple-icons.git",
       branch: "develop",
-      hash: "1da4d733eb0093fff3aa9a65efee8bd79bed8209",
+      hash: "a2d7521052511d0c06dff3b0c3a8e4d66a10ef5a",
     },
   },
   {

--- a/packages/react-icons/src/icons/index.ts
+++ b/packages/react-icons/src/icons/index.ts
@@ -494,7 +494,7 @@ export const icons: IconDefinition[] = [
       remoteDir: "icons/",
       url: "https://github.com/simple-icons/simple-icons.git",
       branch: "develop",
-      hash: "f726999af2714f9ed69d4f60ad36aec9e089af40",
+      hash: "1da4d733eb0093fff3aa9a65efee8bd79bed8209",
     },
   },
   {


### PR DESCRIPTION
The previous commit was from Oct 2, 2021 

New release: https://github.com/simple-icons/simple-icons/releases/tag/8.5.0