### PR TITLE
Add name field to generated package.json files

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,8 +205,8 @@ npm remove @types/react-icons
 
 ```bash
 yarn
-yarn submodule  # fetch icon sources
 cd packages/react-icons
+yarn fetch  # fetch icon sources
 yarn build
 ```
 

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "4.7.1",
+  "version": "4.7.2",
   "command": {
     "version": {
       "push": true

--- a/packages/_react-icons_all-files/package.json
+++ b/packages/_react-icons_all-files/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-icons/all-files",
-  "version": "4.7.1",
+  "version": "4.7.2",
   "description": "SVG React icons of popular icon packs using ES6 imports",
   "author": "Goran Gajic",
   "contributors": [

--- a/packages/_react-icons_all/package.json
+++ b/packages/_react-icons_all/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-icons",
-  "version": "4.7.1",
+  "version": "4.7.2",
   "description": "SVG React icons of popular icon packs using ES6 imports",
   "author": "Goran Gajic",
   "contributors": [

--- a/packages/demo-all-files/package.json
+++ b/packages/demo-all-files/package.json
@@ -1,11 +1,11 @@
 {
   "name": "demo-all-files",
-  "version": "4.7.1",
+  "version": "4.7.2",
   "private": true,
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-icons": "^4.7.1",
+    "react-icons": "^4.7.2",
     "react-scripts": "^5.0.1"
   },
   "scripts": {

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -1,11 +1,11 @@
 {
   "name": "demo",
-  "version": "4.7.1",
+  "version": "4.7.2",
   "private": true,
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-icons": "^4.7.1",
+    "react-icons": "^4.7.2",
     "react-scripts": "^5.0.1"
   },
   "scripts": {

--- a/packages/preview/package.json
+++ b/packages/preview/package.json
@@ -9,7 +9,7 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "version": "4.7.1",
+  "version": "4.7.2",
   "private": true,
   "dependencies": {
     "@loadable/component": "^5.15.2",
@@ -26,7 +26,7 @@
     "prop-types": "^15.7.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-icons": "^4.7.1",
+    "react-icons": "^4.7.2",
     "sass": "^1.55.0",
     "tiny-skeleton-loader-react": "^1.1.0"
   },

--- a/packages/react-icons/VERSIONS
+++ b/packages/react-icons/VERSIONS
@@ -5,25 +5,25 @@
 | [Ionicons 4](https://ionicons.com/) | [MIT](https://github.com/ionic-team/ionicons/blob/master/LICENSE) | 4.6.3 | 696 |
 | [Ionicons 5](https://ionicons.com/) | [MIT](https://github.com/ionic-team/ionicons/blob/master/LICENSE) | 5.5.0 | 1332 |
 | [Material Design icons](http://google.github.io/material-design-icons/) | [Apache License Version 2.0](https://github.com/google/material-design-icons/blob/master/LICENSE) | 4.0.0-12-g63c5cb3060 | 3650 |
-| [Typicons](http://s-ings.com/typicons/) | [CC BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/) | 2.1.2 | 336 |
+| [Typicons](http://s-ings.com/typicons/) | [CC BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/) | v2.1.2 | 336 |
 | [Github Octicons icons](https://octicons.github.com/) | [MIT](https://github.com/primer/octicons/blob/master/LICENSE) | 8.5.0 | 184 |
 | [Feather](https://feathericons.com/) | [MIT](https://github.com/feathericons/feather/blob/master/LICENSE) | 4.28.0 | 286 |
 | [Game Icons](https://game-icons.net/) | [CC BY 3.0](https://creativecommons.org/licenses/by/3.0/) | 12920d6565588f0512542a3cb0cdfd36a497f910 | 4040 |
-| [Weather Icons](https://erikflowers.github.io/weather-icons/) | [SIL OFL 1.1](http://scripts.sil.org/OFL) | 2.0.12 | 219 |
-| [Devicons](https://vorillaz.github.io/devicons/) | [MIT](https://opensource.org/licenses/MIT) | 1.8.0 | 192 |
-| [Ant Design Icons](https://github.com/ant-design/ant-design-icons) | [MIT](https://opensource.org/licenses/MIT) | 4.2.1 | 789 |
-| [Bootstrap Icons](https://github.com/twbs/icons) | [MIT](https://opensource.org/licenses/MIT) | 1.5.0 | 1846 |
-| [Remix Icon](https://github.com/Remix-Design/RemixIcon) | [Apache License Version 2.0](http://www.apache.org/licenses/) | 2.5.0 | 2271 |
-| [Flat Color Icons](https://github.com/icons8/flat-color-icons) | [MIT](https://opensource.org/licenses/MIT) | 1.0.2 | 329 |
-| [Grommet-Icons](https://github.com/grommet/grommet-icons) | [Apache License Version 2.0](http://www.apache.org/licenses/) | 4.6.2 | 615 |
-| [Heroicons](https://github.com/tailwindlabs/heroicons) | [MIT](https://opensource.org/licenses/MIT) | 1.0.4 | 460 |
-| [Heroicons 2](https://github.com/tailwindlabs/heroicons) | [MIT](https://opensource.org/licenses/MIT) | 2.0.8 | 530 |
-| [Simple Icons](https://simpleicons.org/) | [CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/) | 5.16.0 | 2024 |
-| [Simple Line Icons](https://thesabbir.github.io/simple-line-icons/) | [MIT](https://opensource.org/licenses/MIT) | 2.5.5 | 189 |
+| [Weather Icons](https://erikflowers.github.io/weather-icons/) | [SIL OFL 1.1](http://scripts.sil.org/OFL) | 2.0.12-5-g2eec50d | 219 |
+| [Devicons](https://vorillaz.github.io/devicons/) | [MIT](https://opensource.org/licenses/MIT) | 1.8.0-9-gba75593 | 192 |
+| [Ant Design Icons](https://github.com/ant-design/ant-design-icons) | [MIT](https://opensource.org/licenses/MIT) | @ant-design/icons-svg@4.0.0-120-g4666e7f | 789 |
+| [Bootstrap Icons](https://github.com/twbs/icons) | [MIT](https://opensource.org/licenses/MIT) | v1.5.0-60-g496d6a6 | 1846 |
+| [Remix Icon](https://github.com/Remix-Design/RemixIcon) | [Apache License Version 2.0](http://www.apache.org/licenses/) | v2.5.0-2-g943f2e7 | 2271 |
+| [Flat Color Icons](https://github.com/icons8/flat-color-icons) | [MIT](https://opensource.org/licenses/MIT) | v1.0.2-27-g8eccbbb | 329 |
+| [Grommet-Icons](https://github.com/grommet/grommet-icons) | [Apache License Version 2.0](http://www.apache.org/licenses/) | v4.6.2-13-g29f37a8 | 615 |
+| [Heroicons](https://github.com/tailwindlabs/heroicons) | [MIT](https://opensource.org/licenses/MIT) | v1.0.4-12-g1d51214 | 460 |
+| [Heroicons 2](https://github.com/tailwindlabs/heroicons) | [MIT](https://opensource.org/licenses/MIT) | v2.0.8 | 530 |
+| [Simple Icons](https://simpleicons.org/) | [CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/) | 4.14.0-513-gf726999 | 2024 |
+| [Simple Line Icons](https://thesabbir.github.io/simple-line-icons/) | [MIT](https://opensource.org/licenses/MIT) | v2.5.5 | 189 |
 | [IcoMoon Free](https://github.com/Keyamoon/IcoMoon-Free) | [CC BY 4.0 License](https://github.com/Keyamoon/IcoMoon-Free/blob/master/License.txt) | d006795ede82361e1bac1ee76f215cf1dc51e4ca | 491 |
-| [BoxIcons](https://github.com/atisawd/boxicons) | [CC BY 4.0 License](https://github.com/atisawd/boxicons/blob/master/LICENSE) | 2.0.9 | 757 |
+| [BoxIcons](https://github.com/atisawd/boxicons) | [CC BY 4.0 License](https://github.com/atisawd/boxicons/blob/master/LICENSE) | dc81e4561f1ff53ebed4678c32ef08dc2415d636 | 757 |
 | [css.gg](https://github.com/astrit/css.gg) | [MIT](https://opensource.org/licenses/MIT) | 2.0.0 | 704 |
 | [VS Code Icons](https://github.com/microsoft/vscode-codicons) | [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/) | 0.0.23 | 383 |
-| [Tabler Icons](https://github.com/tabler/tabler-icons) | [MIT](https://opensource.org/licenses/MIT) | 1.68.0 | 1978 |
+| [Tabler Icons](https://github.com/tabler/tabler-icons) | [MIT](https://opensource.org/licenses/MIT) | v1.68.0 | 1978 |
 | [Themify Icons](https://github.com/lykmapipo/themify-icons) | [MIT](https://github.com/thecreation/standard-icons/blob/master/modules/themify-icons/LICENSE) | v0.1.2 | 352 |
 | [Radix Icons](https://icons.radix-ui.com) | [MIT](https://github.com/radix-ui/icons/blob/master/LICENSE) | @radix-ui/react-icons@1.0.3-30-g237cd76 | 318 |

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-icons_builders",
   "private": true,
-  "version": "4.7.1",
+  "version": "4.7.2",
   "description": "SVG React icons of popular icon packs using ES6 imports",
   "author": "Goran Gajic",
   "contributors": [

--- a/packages/react-icons/scripts/task_all.ts
+++ b/packages/react-icons/scripts/task_all.ts
@@ -49,6 +49,7 @@ export async function dirInit({ DIST, LIB, rootDir }) {
       [icon.id, "package.json"],
       JSON.stringify(
         {
+          name: icon.id,
           sideEffects: false,
           module: "./index.esm.js",
         },

--- a/packages/react-icons/src/icons/index.ts
+++ b/packages/react-icons/src/icons/index.ts
@@ -262,7 +262,7 @@ export const icons: IconDefinition[] = [
     source: {
       type: "git",
       localName: "devicons",
-      remoteDir: "!SVG/",
+      remoteDir: "\\!SVG/",
       url: "https://github.com/vorillaz/devicons.git",
       branch: "master",
       hash: "ba75593fdf8d66496676a90cbf127d721f73e961",

--- a/packages/react-icons/src/package.json
+++ b/packages/react-icons/src/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "react-icons",
   "main": "./cjs/index.js",
   "module": "./esm/index.js"
 }

--- a/packages/ts-test/package.json
+++ b/packages/ts-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-ts-test",
-  "version": "4.7.1",
+  "version": "4.7.2",
   "private": true,
   "dependencies": {
     "@types/jest": "29.1.2",
@@ -9,7 +9,7 @@
     "@types/react-dom": "^18.0.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-icons": "^4.7.1",
+    "react-icons": "^4.7.2",
     "react-scripts": "5.0.1",
     "typescript": "4.8.4"
   },

--- a/packages/webpack4-test/package.json
+++ b/packages/webpack4-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack4-test",
-  "version": "4.7.1",
+  "version": "4.7.2",
   "main": "index.js",
   "private": true,
   "license": "MIT",
@@ -14,6 +14,6 @@
     "webpack-cli": "^4.10.0"
   },
   "dependencies": {
-    "react-icons": "^4.7.1"
+    "react-icons": "^4.7.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7679,7 +7679,7 @@ __metadata:
     enzyme-to-json: ^3.4.3
     react: ^18.2.0
     react-dom: ^18.2.0
-    react-icons: ^4.7.1
+    react-icons: ^4.7.2
     react-scripts: ^5.0.1
   languageName: unknown
   linkType: soft
@@ -7693,7 +7693,7 @@ __metadata:
     enzyme-to-json: ^3.4.3
     react: ^18.2.0
     react-dom: ^18.2.0
-    react-icons: ^4.7.1
+    react-icons: ^4.7.2
     react-scripts: ^5.0.1
   languageName: unknown
   linkType: soft
@@ -15857,7 +15857,7 @@ __metadata:
     prop-types: ^15.7.2
     react: ^18.2.0
     react-dom: ^18.2.0
-    react-icons: ^4.7.1
+    react-icons: ^4.7.2
     sass: ^1.55.0
     tiny-skeleton-loader-react: ^1.1.0
     typescript: ^4.8.4
@@ -16236,7 +16236,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"react-icons@^4.7.1, react-icons@workspace:packages/_react-icons_all":
+"react-icons@^4.7.2, react-icons@workspace:packages/_react-icons_all":
   version: 0.0.0-use.local
   resolution: "react-icons@workspace:packages/_react-icons_all"
   peerDependencies:
@@ -16391,7 +16391,7 @@ __metadata:
     "@types/react-dom": ^18.0.6
     react: ^18.2.0
     react-dom: ^18.2.0
-    react-icons: ^4.7.1
+    react-icons: ^4.7.2
     react-scripts: 5.0.1
     typescript: 4.8.4
   languageName: unknown
@@ -19595,7 +19595,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "webpack4-test@workspace:packages/webpack4-test"
   dependencies:
-    react-icons: ^4.7.1
+    react-icons: ^4.7.2
     webpack: ^5.74.0
     webpack-cli: ^4.10.0
   languageName: unknown


### PR DESCRIPTION
The name field is required in package.json files according to the spec. Certain tooling that traverse node_modules fail if there is no name field in the package.json files ([api-extractor](https://www.npmjs.com/package/@microsoft/api-extractor)).

Also:

* update VERSIONS,
* update README.md
* escape exclamation mark in path for the svg icons in the devicons package