### PR TITLE
added debounce to preview search to limit unnecessary calls

### DIFF
--- a/packages/preview/package.json
+++ b/packages/preview/package.json
@@ -20,6 +20,7 @@
     "copy-to-clipboard": "^3.2.0",
     "css-loader": "6.7.1",
     "ignore-loader": "^0.1.2",
+    "lodash": "^4.17.21",
     "next": "^12.3.1",
     "next-pwa": "^5.6.0",
     "prism-react-renderer": "^1.0.2",

--- a/packages/preview/package.json
+++ b/packages/preview/package.json
@@ -20,7 +20,7 @@
     "copy-to-clipboard": "^3.2.0",
     "css-loader": "6.7.1",
     "ignore-loader": "^0.1.2",
-    "lodash": "^4.17.21",
+    "lodash.debounce": "^4.0.8",
     "next": "^12.3.1",
     "next-pwa": "^5.6.0",
     "prism-react-renderer": "^1.0.2",

--- a/packages/preview/src/components/@core/sidebar/index.tsx
+++ b/packages/preview/src/components/@core/sidebar/index.tsx
@@ -2,14 +2,14 @@ import { ALL_ICONS } from "@utils/icon";
 import { Context } from "@utils/search-context";
 import { useRouter } from "next/router";
 import React, { useEffect, useMemo, useState } from "react";
-import debounce from "lodash/debounce";
+import debounce from "lodash.debounce";
 
 import ActiveLink from "../active-link";
 import Heading from "../heading";
 
 const searchPath = "/search";
 
-const DEBOUNCE_WAIT_TIME = 300 as const;
+const DEBOUNCE_WAIT_TIME = 300;
 
 export default function Sidebar() {
   const iconsList = ALL_ICONS.sort((a, b) => (a.name > b.name ? 1 : -1));
@@ -33,10 +33,7 @@ export default function Sidebar() {
     });
   };
 
-  const debouncedSearchHandler = useMemo(
-    () => debounce(onSearch, DEBOUNCE_WAIT_TIME),
-    []
-  );
+  const debouncedSearchHandler = debounce(onSearch, DEBOUNCE_WAIT_TIME);
 
   const goToSearch = (e) => {
     if (!router.asPath.includes(searchPath)) router.push(searchPath);

--- a/packages/preview/src/components/@core/sidebar/index.tsx
+++ b/packages/preview/src/components/@core/sidebar/index.tsx
@@ -1,12 +1,15 @@
 import { ALL_ICONS } from "@utils/icon";
 import { Context } from "@utils/search-context";
 import { useRouter } from "next/router";
-import React, { useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
+import debounce from "lodash/debounce";
 
 import ActiveLink from "../active-link";
 import Heading from "../heading";
 
 const searchPath = "/search";
+
+const DEBOUNCE_WAIT_TIME = 300 as const;
 
 export default function Sidebar() {
   const iconsList = ALL_ICONS.sort((a, b) => (a.name > b.name ? 1 : -1));
@@ -30,6 +33,11 @@ export default function Sidebar() {
     });
   };
 
+  const debouncedSearchHandler = useMemo(
+    () => debounce(onSearch, DEBOUNCE_WAIT_TIME),
+    []
+  );
+
   const goToSearch = (e) => {
     if (!router.asPath.includes(searchPath)) router.push(searchPath);
   };
@@ -39,6 +47,14 @@ export default function Sidebar() {
       window && window.history.back();
     }
   };
+
+  // Stop the invocation of the debounced function
+  // after unmounting
+  useEffect(() => {
+    return () => {
+      debouncedSearchHandler.cancel();
+    };
+  }, []);
 
   return (
     <div className="sidebar pt3">
@@ -52,7 +68,7 @@ export default function Sidebar() {
           placeholder="🔍 Search Icons"
           onFocus={goToSearch}
           onBlur={onBlur}
-          onChange={onSearch}
+          onChange={debouncedSearchHandler}
           value={inputQuery !== null ? inputQuery : query}
           autoComplete="off"
           autoCorrect="off"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15851,6 +15851,7 @@ __metadata:
     copy-to-clipboard: ^3.2.0
     css-loader: 6.7.1
     ignore-loader: ^0.1.2
+    lodash.debounce: ^4.0.8
     next: ^12.3.1
     next-pwa: ^5.6.0
     prism-react-renderer: ^1.0.2


### PR DESCRIPTION
Added a debounce function from `lodash ^4.17.21` which is only `~4kB` to 

- Optimize search functionality
- Do less API calls  