### PR TITLE
Remove deprecated "main" field from package.json

### DIFF
--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -8,7 +8,6 @@
     "kamijin_fanta <kamijin@live.jp>"
   ],
   "license": "MIT",
-  "main": "lib",
   "types": "./lib/esm/index.d.ts",
   "sideEffects": false,
   "repository": {


### PR DESCRIPTION
Across multiple frameworks, users receive a `[DEP0128] DeprecationWarning: Invalid 'main' field in ...` warning. Removing this line fixes it. 

Issue: #509