### PR TITLE
fix: Invalid 'main' field in package.json

### DIFF
--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -8,7 +8,6 @@
     "kamijin_fanta <kamijin@live.jp>"
   ],
   "license": "MIT",
-  "main": "lib",
   "types": "./lib/esm/index.d.ts",
   "sideEffects": false,
   "repository": {


### PR DESCRIPTION
detail warning:  `[DEP0128] DeprecationWarning: Invalid 'main' field`
![image](https://user-images.githubusercontent.com/70096611/219953940-bb48ef20-9428-4090-a21b-234c6d163677.png)
