### PR TITLE
Add Lucide icons

### DIFF
--- a/packages/react-icons/VERSIONS
+++ b/packages/react-icons/VERSIONS
@@ -8,6 +8,7 @@
 | [Typicons](http://s-ings.com/typicons/) | [CC BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/) | 2.1.2 | 336 |
 | [Github Octicons icons](https://octicons.github.com/) | [MIT](https://github.com/primer/octicons/blob/master/LICENSE) | 8.5.0 | 184 |
 | [Feather](https://feathericons.com/) | [MIT](https://github.com/feathericons/feather/blob/master/LICENSE) | 4.28.0 | 286 |
+| [Lucide](https://lucide.dev/) | [ISC](https://github.com/lucide-icons/lucide/blob/main/LICENSE) | v4.8.1-snapshot.1-4-g585e630f | 902 |
 | [Game Icons](https://game-icons.net/) | [CC BY 3.0](https://creativecommons.org/licenses/by/3.0/) | 12920d6565588f0512542a3cb0cdfd36a497f910 | 4040 |
 | [Weather Icons](https://erikflowers.github.io/weather-icons/) | [SIL OFL 1.1](http://scripts.sil.org/OFL) | 2.0.12 | 219 |
 | [Devicons](https://vorillaz.github.io/devicons/) | [MIT](https://opensource.org/licenses/MIT) | 1.8.0 | 192 |

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -38,6 +38,7 @@
     "ionicons": "^4.6.3",
     "ionicons-5": "npm:ionicons@5",
     "lerna": "^3.20.2",
+    "lucide-static": "^0.192.0",
     "octicons": "^8.5.0",
     "p-queue": "^7.3.0",
     "prettier": "^2.7.1",

--- a/packages/react-icons/src/icons/index.ts
+++ b/packages/react-icons/src/icons/index.ts
@@ -203,6 +203,22 @@ export const icons: IconDefinition[] = [
     licenseUrl: "https://github.com/feathericons/feather/blob/master/LICENSE",
   },
   {
+    id: "lu",
+    name: "Lucide",
+    contents: [
+      {
+        files: path.resolve(
+          path.dirname(require.resolve("lucide-static")),
+          "../icons/*.svg"
+        ),
+        formatter: (name) => `Lu${name}`,
+      },
+    ],
+    projectUrl: "https://lucide.dev/",
+    license: "ISC",
+    licenseUrl: "https://github.com/lucide-icons/lucide/blob/main/LICENSE",
+  },
+  {
     id: "gi",
     name: "Game Icons",
     contents: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -12943,6 +12943,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lucide-static@npm:^0.192.0":
+  version: 0.192.0
+  resolution: "lucide-static@npm:0.192.0"
+  checksum: e068255b447907b9c85235a85161c243f98c8e519b081733ec4186f5601ef33e132722cd799de58d89cf61543035fb742205355251fac6949c953ffdeb64627c
+  languageName: node
+  linkType: hard
+
 "macos-release@npm:^2.2.0":
   version: 2.4.1
   resolution: "macos-release@npm:2.4.1"
@@ -16244,6 +16251,7 @@ __metadata:
     ionicons: ^4.6.3
     ionicons-5: "npm:ionicons@5"
     lerna: ^3.20.2
+    lucide-static: ^0.192.0
     octicons: ^8.5.0
     p-queue: ^7.3.0
     prettier: ^2.7.1


### PR DESCRIPTION
Add Lucide icons, updated version of https://github.com/react-icons/react-icons/pull/602.

@kamijin-fanta I pushed an updated version of [an older PR](https://github.com/react-icons/react-icons/pull/602) which hopefully unblocks getting this shipped. Adding these will make a whole bunch of folks' life easier 🙏🏼 ❤️ 