### PR TITLE
feat: add fontawesome 6

### DIFF
--- a/packages/react-icons/VERSIONS
+++ b/packages/react-icons/VERSIONS
@@ -2,6 +2,7 @@
 | --- | --- | --- | ---: |
 | [Circum Icons](https://circumicons.com/) | [MPL-2.0 license](https://github.com/Klarr-Agency/Circum-Icons/blob/main/LICENSE) | 1.0.0 | 288 |
 | [Font Awesome 5](https://fontawesome.com/) | [CC BY 4.0 License](https://creativecommons.org/licenses/by/4.0/) | 5.15.4-3-gafecf2a | 1612 |
+| [Font Awesome 6](https://fontawesome.com/) | [CC BY 4.0 License](https://creativecommons.org/licenses/by/4.0/) | 6.4.0 | 2020 |
 | [Ionicons 4](https://ionicons.com/) | [MIT](https://github.com/ionic-team/ionicons/blob/master/LICENSE) | 4.6.3 | 696 |
 | [Ionicons 5](https://ionicons.com/) | [MIT](https://github.com/ionic-team/ionicons/blob/master/LICENSE) | 5.5.0 | 1332 |
 | [Material Design icons](http://google.github.io/material-design-icons/) | [Apache License Version 2.0](https://github.com/google/material-design-icons/blob/master/LICENSE) | 4.0.0-61-g511eea577b | 4341 |

--- a/packages/react-icons/src/icons/index.ts
+++ b/packages/react-icons/src/icons/index.ts
@@ -58,6 +58,37 @@ export const icons: IconDefinition[] = [
     },
   },
   {
+    id: "fa6",
+    name: "Font Awesome 6",
+    contents: [
+      {
+        files: path.resolve(
+          __dirname,
+          "../../icons/fontawesome-6/svgs/+(brands|solid)/*.svg"
+        ),
+        formatter: (name) => `Fa6${name}`,
+      },
+      {
+        files: path.resolve(
+          __dirname,
+          "../../icons/fontawesome-6/svgs/regular/*.svg"
+        ),
+        formatter: (name) => `Fa6Reg${name}`,
+      },
+    ],
+    projectUrl: "https://fontawesome.com/",
+    license: "CC BY 4.0 License",
+    licenseUrl: "https://creativecommons.org/licenses/by/4.0/",
+    source: {
+      type: "git",
+      localName: "fontawesome-6",
+      remoteDir: "svgs/",
+      url: "https://github.com/FortAwesome/Font-Awesome.git",
+      branch: "6.x",
+      hash: "0698449d50f2b95517562295a59d414afc68b369",
+    },
+  },
+  {
     id: "io",
     name: "Ionicons 4",
     contents: [

--- a/packages/react-icons/src/icons/index.ts
+++ b/packages/react-icons/src/icons/index.ts
@@ -66,14 +66,14 @@ export const icons: IconDefinition[] = [
           __dirname,
           "../../icons/fontawesome-6/svgs/+(brands|solid)/*.svg"
         ),
-        formatter: (name) => `Fa6${name}`,
+        formatter: (name) => `Fa${name}`,
       },
       {
         files: path.resolve(
           __dirname,
           "../../icons/fontawesome-6/svgs/regular/*.svg"
         ),
-        formatter: (name) => `Fa6Reg${name}`,
+        formatter: (name) => `FaReg${name}`,
       },
     ],
     projectUrl: "https://fontawesome.com/",


### PR DESCRIPTION
Fontawesome 6 is the lastest version why not add it next to the old one ?

- Icon count: 2020
- Licence: CC BY 4.0 License
- Prefix: Fa6

preview: 
![image](https://user-images.githubusercontent.com/1371193/232234664-7f0fb579-6673-4759-85d9-ccbc986b83a3.png)

Next major release: rename Fa -> Fa5 and Fa6 -> Fa ?