### PR TITLE
Feature: additional variants for BoxIcons (Solid/Logo)

### DIFF
--- a/packages/react-icons/VERSIONS
+++ b/packages/react-icons/VERSIONS
@@ -21,7 +21,7 @@
 | [Simple Icons](https://simpleicons.org/) | [CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/) | 8.6.0 | 2437 |
 | [Simple Line Icons](https://thesabbir.github.io/simple-line-icons/) | [MIT](https://opensource.org/licenses/MIT) | 2.5.5 | 189 |
 | [IcoMoon Free](https://github.com/Keyamoon/IcoMoon-Free) | [CC BY 4.0 License](https://github.com/Keyamoon/IcoMoon-Free/blob/master/License.txt) | d006795ede82361e1bac1ee76f215cf1dc51e4ca | 491 |
-| [BoxIcons](https://github.com/atisawd/boxicons) | [CC BY 4.0 License](https://github.com/atisawd/boxicons/blob/master/LICENSE) | 2.1.4 | 814 |
+| [BoxIcons](https://github.com/atisawd/boxicons) | [CC BY 4.0 License](https://github.com/atisawd/boxicons/blob/master/LICENSE) | 2.1.4 | 1634 |
 | [css.gg](https://github.com/astrit/css.gg) | [MIT](https://opensource.org/licenses/MIT) | 2.0.0 | 704 |
 | [VS Code Icons](https://github.com/microsoft/vscode-codicons) | [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/) | 0.0.32 | 423 |
 | [Tabler Icons](https://github.com/tabler/tabler-icons) | [MIT](https://opensource.org/licenses/MIT) | 2.7.0 | 3455 |

--- a/packages/react-icons/src/icons/index.ts
+++ b/packages/react-icons/src/icons/index.ts
@@ -554,6 +554,20 @@ export const icons: IconDefinition[] = [
         ),
         formatter: (name) => `Bi${name.replace("Bx", "")}`,
       },
+      {
+        files: path.resolve(
+          __dirname,
+          "../../icons/boxicons/svg/solid/*.svg"
+        ),
+        formatter: (name) => `BiSolid${name.replace("Bxs", "")}`,
+      },
+      {
+        files: path.resolve(
+          __dirname,
+          "../../icons/boxicons/svg/logos/*.svg"
+        ),
+        formatter: (name) => `BiLogo${name.replace("Bxl", "")}`,
+      },
     ],
     projectUrl: "https://github.com/atisawd/boxicons",
     license: "CC BY 4.0 License",
@@ -561,7 +575,7 @@ export const icons: IconDefinition[] = [
     source: {
       type: "git",
       localName: "boxicons",
-      remoteDir: "svg/regular/",
+      remoteDir: "svg/",
       url: "https://github.com/atisawd/boxicons.git",
       branch: "master",
       hash: "9ffa9136e8681886bb7bd2145cd4098717ce1c11",

--- a/packages/react-icons/src/icons/index.ts
+++ b/packages/react-icons/src/icons/index.ts
@@ -555,17 +555,11 @@ export const icons: IconDefinition[] = [
         formatter: (name) => `Bi${name.replace("Bx", "")}`,
       },
       {
-        files: path.resolve(
-          __dirname,
-          "../../icons/boxicons/svg/solid/*.svg"
-        ),
+        files: path.resolve(__dirname, "../../icons/boxicons/svg/solid/*.svg"),
         formatter: (name) => `BiSolid${name.replace("Bxs", "")}`,
       },
       {
-        files: path.resolve(
-          __dirname,
-          "../../icons/boxicons/svg/logos/*.svg"
-        ),
+        files: path.resolve(__dirname, "../../icons/boxicons/svg/logos/*.svg"),
         formatter: (name) => `BiLogo${name.replace("Bxl", "")}`,
       },
     ],


### PR DESCRIPTION
#  Description
This pull request contains additional BoxIcon variants, `Solid` & `Logo`. 

Naming convention examples

Regular:    ```
    <BiShield />
    ```
Logo:    ```
    <BiLogoTiktok />
    ```
Solid:    ```
    <BiSolidShield />
    ```

The `Regular` icons are left as is, to avoid breaking changes