### PR TITLE
Fix: yarn cache in GitHub Actions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -18,18 +18,9 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+          cache: "yarn"
       - name: corepack
         run: corepack enable
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v3
-        id: yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
       - name: Install dependencies
         run: yarn --immutable
       - name: Formatter


### PR DESCRIPTION
Failed to get yarn cache in Node.js CI.
https://github.com/react-icons/react-icons/actions/runs/4539744631/jobs/7999901702#step:6:1

We can get yarn cache using only actions/setup-node ([FYI](https://github.com/actions/setup-node/tree/a9893b0cfb0821c9c7b5fec28a6a2e6cdd5e20a4#caching-global-packages-data)). So I remove yarn-cache step, and use `cache` option in setup-node.
