### PR TITLE
Fix: Always render title tag in SVG elements

### DIFF
--- a/packages/demo/src/App.test.js
+++ b/packages/demo/src/App.test.js
@@ -13,3 +13,11 @@ it("renders without crashing", () => {
 it("snapshot test", () => {
   expect(shallow(<App />)).toMatchSnapshot();
 });
+
+it("always includes a title", () => {
+  shallow(<App />);
+  const icons = document.getElementsByTagName("svg");
+  for (let i = 0; i < icons.length; i++) {
+    expect(icons[i].getElementsByTagName("title").length).toBe(1);
+  }
+});

--- a/packages/react-icons/src/iconBase.tsx
+++ b/packages/react-icons/src/iconBase.tsx
@@ -66,7 +66,7 @@ export function IconBase(
         width={computedSize}
         xmlns="http://www.w3.org/2000/svg"
       >
-        {title && <title>{title}</title>}
+        {<title>{title || "Icon"}</title>}
         {props.children}
       </svg>
     );


### PR DESCRIPTION
This PR addresses accessibility issues discussed in #584 by rendering the title tag with "Icon" if no `title` prop is provided, giving assistive technologies and search engines the context that the SVG is an image of an icon.