### PR TITLE
add material design symbol

### DIFF
--- a/packages/react-icons/VERSIONS
+++ b/packages/react-icons/VERSIONS
@@ -1,31 +1,32 @@
-| Icon Library | License | Version | Count |
-| --- | --- | --- | ---: |
-| [Circum Icons](https://circumicons.com/) | [MPL-2.0 license](https://github.com/Klarr-Agency/Circum-Icons/blob/main/LICENSE) | 1.0.0 | 288 |
-| [Font Awesome 5](https://fontawesome.com/) | [CC BY 4.0 License](https://creativecommons.org/licenses/by/4.0/) | 5.15.4-3-gafecf2a | 1612 |
-| [Font Awesome 6](https://fontawesome.com/) | [CC BY 4.0 License](https://creativecommons.org/licenses/by/4.0/) | 6.4.0 | 2020 |
-| [Ionicons 4](https://ionicons.com/) | [MIT](https://github.com/ionic-team/ionicons/blob/master/LICENSE) | 4.6.3 | 696 |
-| [Ionicons 5](https://ionicons.com/) | [MIT](https://github.com/ionic-team/ionicons/blob/master/LICENSE) | 5.5.0 | 1332 |
-| [Material Design icons](http://google.github.io/material-design-icons/) | [Apache License Version 2.0](https://github.com/google/material-design-icons/blob/master/LICENSE) | 4.0.0-61-g511eea577b | 4341 |
-| [Typicons](http://s-ings.com/typicons/) | [CC BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/) | 2.1.2 | 336 |
-| [Github Octicons icons](https://octicons.github.com/) | [MIT](https://github.com/primer/octicons/blob/master/LICENSE) | 18.3.0 | 264 |
-| [Feather](https://feathericons.com/) | [MIT](https://github.com/feathericons/feather/blob/master/LICENSE) | 4.28.0 | 286 |
-| [Lucide](https://lucide.dev/) | [ISC](https://github.com/lucide-icons/lucide/blob/main/LICENSE) | v4.8.1-snapshot.1-4-g585e630f | 902 |
-| [Game Icons](https://game-icons.net/) | [CC BY 3.0](https://creativecommons.org/licenses/by/3.0/) | 12920d6565588f0512542a3cb0cdfd36a497f910 | 4040 |
-| [Weather Icons](https://erikflowers.github.io/weather-icons/) | [SIL OFL 1.1](http://scripts.sil.org/OFL) | 2.0.12 | 219 |
-| [Devicons](https://vorillaz.github.io/devicons/) | [MIT](https://opensource.org/licenses/MIT) | 1.8.0 | 192 |
-| [Ant Design Icons](https://github.com/ant-design/ant-design-icons) | [MIT](https://opensource.org/licenses/MIT) | 4.2.1 | 789 |
-| [Bootstrap Icons](https://github.com/twbs/icons) | [MIT](https://opensource.org/licenses/MIT) | 1.10.3 | 2592 |
-| [Remix Icon](https://github.com/Remix-Design/RemixIcon) | [Apache License Version 2.0](http://www.apache.org/licenses/) | 2.5.0 | 2271 |
-| [Flat Color Icons](https://github.com/icons8/flat-color-icons) | [MIT](https://opensource.org/licenses/MIT) | 1.0.2 | 329 |
-| [Grommet-Icons](https://github.com/grommet/grommet-icons) | [Apache License Version 2.0](http://www.apache.org/licenses/) | 4.9.0 | 620 |
-| [Heroicons](https://github.com/tailwindlabs/heroicons) | [MIT](https://opensource.org/licenses/MIT) | 1.0.6 | 460 |
-| [Heroicons 2](https://github.com/tailwindlabs/heroicons) | [MIT](https://opensource.org/licenses/MIT) | 2.0.16 | 584 |
-| [Simple Icons](https://simpleicons.org/) | [CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/) | 8.6.0 | 2437 |
-| [Simple Line Icons](https://thesabbir.github.io/simple-line-icons/) | [MIT](https://opensource.org/licenses/MIT) | 2.5.5 | 189 |
-| [IcoMoon Free](https://github.com/Keyamoon/IcoMoon-Free) | [CC BY 4.0 License](https://github.com/Keyamoon/IcoMoon-Free/blob/master/License.txt) | d006795ede82361e1bac1ee76f215cf1dc51e4ca | 491 |
-| [BoxIcons](https://github.com/atisawd/boxicons) | [CC BY 4.0 License](https://github.com/atisawd/boxicons/blob/master/LICENSE) | 2.1.4 | 1634 |
-| [css.gg](https://github.com/astrit/css.gg) | [MIT](https://opensource.org/licenses/MIT) | 2.0.0 | 704 |
-| [VS Code Icons](https://github.com/microsoft/vscode-codicons) | [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/) | 0.0.32 | 423 |
-| [Tabler Icons](https://github.com/tabler/tabler-icons) | [MIT](https://opensource.org/licenses/MIT) | 2.7.0 | 3455 |
-| [Themify Icons](https://github.com/lykmapipo/themify-icons) | [MIT](https://github.com/thecreation/standard-icons/blob/master/modules/themify-icons/LICENSE) | v0.1.2-2-g9600186 | 352 |
-| [Radix Icons](https://icons.radix-ui.com) | [MIT](https://github.com/radix-ui/icons/blob/master/LICENSE) | @modulz/generate-icon-lib@0.2.1 | 318 |
+| Icon Library                                                              | License                                                                                           | Version                                  | Count |
+| ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- | ---------------------------------------- | ----: |
+| [Circum Icons](https://circumicons.com/)                                  | [MPL-2.0 license](https://github.com/Klarr-Agency/Circum-Icons/blob/main/LICENSE)                 | 1.0.0                                    |   288 |
+| [Font Awesome 5](https://fontawesome.com/)                                | [CC BY 4.0 License](https://creativecommons.org/licenses/by/4.0/)                                 | 5.15.4-3-gafecf2a                        |  1612 |
+| [Font Awesome 6](https://fontawesome.com/)                                | [CC BY 4.0 License](https://creativecommons.org/licenses/by/4.0/)                                 | 6.4.0                                    |  2020 |
+| [Ionicons 4](https://ionicons.com/)                                       | [MIT](https://github.com/ionic-team/ionicons/blob/master/LICENSE)                                 | 4.6.3                                    |   696 |
+| [Ionicons 5](https://ionicons.com/)                                       | [MIT](https://github.com/ionic-team/ionicons/blob/master/LICENSE)                                 | 5.5.0                                    |  1332 |
+| [Material Design icons](http://google.github.io/material-design-icons/)   | [Apache License Version 2.0](https://github.com/google/material-design-icons/blob/master/LICENSE) | 4.0.0-61-g511eea577b                     |  4341 |
+| [Material Design symbols](http://google.github.io/material-design-icons/) | [Apache License Version 2.0](https://github.com/google/material-design-icons/blob/master/LICENSE) | 0.5.5                                    |  2803 |
+| [Typicons](http://s-ings.com/typicons/)                                   | [CC BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/)                                   | 2.1.2                                    |   336 |
+| [Github Octicons icons](https://octicons.github.com/)                     | [MIT](https://github.com/primer/octicons/blob/master/LICENSE)                                     | 18.3.0                                   |   264 |
+| [Feather](https://feathericons.com/)                                      | [MIT](https://github.com/feathericons/feather/blob/master/LICENSE)                                | 4.28.0                                   |   286 |
+| [Lucide](https://lucide.dev/)                                             | [ISC](https://github.com/lucide-icons/lucide/blob/main/LICENSE)                                   | v4.8.1-snapshot.2-8-gf796645b            |  1042 |
+| [Game Icons](https://game-icons.net/)                                     | [CC BY 3.0](https://creativecommons.org/licenses/by/3.0/)                                         | 12920d6565588f0512542a3cb0cdfd36a497f910 |  4040 |
+| [Weather Icons](https://erikflowers.github.io/weather-icons/)             | [SIL OFL 1.1](http://scripts.sil.org/OFL)                                                         | 2.0.12                                   |   219 |
+| [Devicons](https://vorillaz.github.io/devicons/)                          | [MIT](https://opensource.org/licenses/MIT)                                                        | 1.8.0                                    |   192 |
+| [Ant Design Icons](https://github.com/ant-design/ant-design-icons)        | [MIT](https://opensource.org/licenses/MIT)                                                        | 4.2.1                                    |   789 |
+| [Bootstrap Icons](https://github.com/twbs/icons)                          | [MIT](https://opensource.org/licenses/MIT)                                                        | 1.10.3                                   |  2592 |
+| [Remix Icon](https://github.com/Remix-Design/RemixIcon)                   | [Apache License Version 2.0](http://www.apache.org/licenses/)                                     | 2.5.0                                    |  2271 |
+| [Flat Color Icons](https://github.com/icons8/flat-color-icons)            | [MIT](https://opensource.org/licenses/MIT)                                                        | 1.0.2                                    |   329 |
+| [Grommet-Icons](https://github.com/grommet/grommet-icons)                 | [Apache License Version 2.0](http://www.apache.org/licenses/)                                     | 4.9.0                                    |   620 |
+| [Heroicons](https://github.com/tailwindlabs/heroicons)                    | [MIT](https://opensource.org/licenses/MIT)                                                        | 1.0.6                                    |   460 |
+| [Heroicons 2](https://github.com/tailwindlabs/heroicons)                  | [MIT](https://opensource.org/licenses/MIT)                                                        | 2.0.16                                   |   584 |
+| [Simple Icons](https://simpleicons.org/)                                  | [CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/)                           | 8.6.0                                    |  2437 |
+| [Simple Line Icons](https://thesabbir.github.io/simple-line-icons/)       | [MIT](https://opensource.org/licenses/MIT)                                                        | 2.5.5                                    |   189 |
+| [IcoMoon Free](https://github.com/Keyamoon/IcoMoon-Free)                  | [CC BY 4.0 License](https://github.com/Keyamoon/IcoMoon-Free/blob/master/License.txt)             | d006795ede82361e1bac1ee76f215cf1dc51e4ca |   491 |
+| [BoxIcons](https://github.com/atisawd/boxicons)                           | [CC BY 4.0 License](https://github.com/atisawd/boxicons/blob/master/LICENSE)                      | 2.1.4                                    |  1634 |
+| [css.gg](https://github.com/astrit/css.gg)                                | [MIT](https://opensource.org/licenses/MIT)                                                        | 2.0.0                                    |   704 |
+| [VS Code Icons](https://github.com/microsoft/vscode-codicons)             | [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)                                         | 0.0.32                                   |   423 |
+| [Tabler Icons](https://github.com/tabler/tabler-icons)                    | [MIT](https://opensource.org/licenses/MIT)                                                        | 2.7.0                                    |  3455 |
+| [Themify Icons](https://github.com/lykmapipo/themify-icons)               | [MIT](https://github.com/thecreation/standard-icons/blob/master/modules/themify-icons/LICENSE)    | v0.1.2-2-g9600186                        |   352 |
+| [Radix Icons](https://icons.radix-ui.com)                                 | [MIT](https://github.com/radix-ui/icons/blob/master/LICENSE)                                      | @modulz/generate-icon-lib@0.2.1          |   318 |

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "@babel/cli": "^7.19.3",
     "@babel/core": "^7.19.3",
+    "@material-symbols/svg-400": "^0.5.5",
     "@primer/octicons": "^18.3.0",
     "@types/react": "^18.0.21",
     "camelcase": "^7.0.0",

--- a/packages/react-icons/src/icons/index.ts
+++ b/packages/react-icons/src/icons/index.ts
@@ -181,6 +181,40 @@ export const icons: IconDefinition[] = [
     },
   },
   {
+    id: "mds",
+    name: "Material Design symbols",
+    contents: [
+      {
+        files: path.resolve(
+          __dirname,
+          "../../../../node_modules/@material-symbols/svg-400/rounded/!(*-fill*).svg"
+        ),
+        formatter: (name) => `Mds${name}Round`,
+        processWithSVGO: false,
+      },
+      {
+        files: path.resolve(
+          __dirname,
+          "../../../../node_modules/@material-symbols/svg-400/sharp/!(*-fill*).svg"
+        ),
+        formatter: (name) => `Mds${name}Sharp`,
+        processWithSVGO: false,
+      },
+      {
+        files: path.resolve(
+          __dirname,
+          "../../../../node_modules/@material-symbols/svg-400/outlined/!(*-fill*).svg"
+        ),
+        formatter: (name) => `Mds${name}Outlined`,
+        processWithSVGO: false,
+      },
+    ],
+    projectUrl: "http://google.github.io/material-design-icons/",
+    license: "Apache License Version 2.0",
+    licenseUrl:
+      "https://github.com/google/material-design-icons/blob/master/LICENSE",
+  },
+  {
     id: "ti",
     name: "Typicons",
     contents: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -3338,6 +3338,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@material-symbols/svg-400@npm:^0.5.5":
+  version: 0.5.5
+  resolution: "@material-symbols/svg-400@npm:0.5.5"
+  checksum: 0e22147c225dc7918bdca9ea3580d883fc9d61eec7b9b81da5f692c4efe13235bf8b9b6b94ee6b3791fa6ba3010035ad834f703abcd5945be567403cb678af84
+  languageName: node
+  linkType: hard
+
 "@mrmlnc/readdir-enhanced@npm:^2.2.1":
   version: 2.2.1
   resolution: "@mrmlnc/readdir-enhanced@npm:2.2.1"
@@ -16239,6 +16246,7 @@ __metadata:
   dependencies:
     "@babel/cli": ^7.19.3
     "@babel/core": ^7.19.3
+    "@material-symbols/svg-400": ^0.5.5
     "@primer/octicons": ^18.3.0
     "@types/react": ^18.0.21
     camelcase: ^7.0.0


### PR DESCRIPTION
- ref #619
- Google repositories are huge and increase build time significantly
- Use the third-party maintained @material-symbols/svg-400 package instead
