### PR TITLE
feature: add download button to download icon as svg

### DIFF
--- a/packages/preview/src/components/@core/icon/index.tsx
+++ b/packages/preview/src/components/@core/icon/index.tsx
@@ -1,6 +1,7 @@
 import toast from "cogo-toast";
 import copy from "copy-to-clipboard";
 import React from "react";
+import { TbCloudDownload } from "react-icons/tb";
 
 function Icon({ icon, name, highlightPattern = null }) {
   const copyToClipboard = () => {
@@ -8,6 +9,26 @@ function Icon({ icon, name, highlightPattern = null }) {
     toast.success(`Copied '${name}' to clipboard`, {
       position: "bottom-center",
     });
+  };
+
+  const downloadSvg = (e: React.MouseEvent<SVGElement>) => {
+    e.stopPropagation();
+
+    const iconElement = document.getElementById(name).firstChild as Element;
+
+    const svgBlob = new Blob(
+      ['<?xml version="1.0" standalone="no"?>\r\n', iconElement.outerHTML],
+      { type: "image/svg+xml;charset=utf-8" }
+    );
+
+    const downloadLink = Object.assign(document.createElement("a"), {
+      href: URL.createObjectURL(svgBlob),
+      download: `${name}.svg`,
+    });
+
+    document.body.appendChild(downloadLink);
+    downloadLink.click();
+    document.body.removeChild(downloadLink);
   };
 
   const highlightedName = () => {
@@ -20,7 +41,10 @@ function Icon({ icon, name, highlightPattern = null }) {
 
   return (
     <div className="item" tabIndex={0} onClick={copyToClipboard} key={name}>
-      <div className="icon h2">{typeof icon === "function" && icon()}</div>
+      <div className="icon h2" id={name}>
+        {typeof icon === "function" && icon()}
+        <TbCloudDownload className="download" onClick={downloadSvg} />
+      </div>
       <div className="name">{highlightedName()}</div>
     </div>
   );

--- a/packages/preview/src/styles/_components.scss
+++ b/packages/preview/src/styles/_components.scss
@@ -162,6 +162,7 @@ a {
 
     .icon {
       min-height: 64px;
+      position: relative;
       display: flex;
       align-items: center;
       justify-content: center;
@@ -171,6 +172,15 @@ a {
         0 1px 2px 0 rgba(0, 0, 0, 0.06);
       border: 2px solid transparent;
       font-size: 1.6em;
+
+      .download {
+        height: 16px;
+        color: rgba(0, 0, 0, 0.5);
+        position: absolute;
+        bottom: 4px;
+        right: 4px;
+        cursor: pointer;
+      }
     }
 
     &:hover {


### PR DESCRIPTION
I implemented the feature suggested in #463

Each icon now shows a small download button in the lower right corner. When hitting the download button, a svg file is downloaded with the respective icon.
![image](https://github.com/react-icons/react-icons/assets/34894514/6f87721b-6464-4317-9a2e-5a6242029b4f)

Thanks @vensauro for your infos in https://github.com/react-icons/react-icons/issues/463#issuecomment-1497975150, they made it really easy to implement! :)