### PR TITLE
Add support for ESM in Node.js

### DIFF
--- a/packages/react-icons/scripts/task_all.ts
+++ b/packages/react-icons/scripts/task_all.ts
@@ -22,7 +22,7 @@ export async function dirInit({ DIST, LIB, rootDir }) {
   const write = (filePath, str) =>
     fs.writeFile(path.resolve(DIST, ...filePath), str, "utf8").catch(ignore);
 
-  const initFiles = ["index.d.ts", "index.esm.js", "index.js"];
+  const initFiles = ["index.d.ts", "index.mjs", "index.js"];
 
   for (const icon of icons) {
     await fs.mkdir(path.resolve(DIST, icon.id)).catch(ignore);
@@ -32,7 +32,7 @@ export async function dirInit({ DIST, LIB, rootDir }) {
       "// THIS FILE IS AUTO GENERATED\nvar GenIcon = require('../lib').GenIcon\n"
     );
     await write(
-      [icon.id, "index.esm.js"],
+      [icon.id, "index.mjs"],
       "// THIS FILE IS AUTO GENERATED\nimport { GenIcon } from '../lib';\n"
     );
     await write(
@@ -43,8 +43,7 @@ export async function dirInit({ DIST, LIB, rootDir }) {
       [icon.id, "package.json"],
       JSON.stringify(
         {
-          sideEffects: false,
-          module: "./index.esm.js",
+          sideEffects: false
         },
         null,
         2
@@ -78,10 +77,10 @@ export async function writeIconModule(icon, { DIST, LIB, rootDir }) {
       if (exists.has(name)) continue;
       exists.add(name);
 
-      // write like: module/fa/index.esm.js
+      // write like: module/fa/index.mjs
       const modRes = iconRowTemplate(icon, name, iconData, "module");
       await fs.appendFile(
-        path.resolve(DIST, icon.id, "index.esm.js"),
+        path.resolve(DIST, icon.id, "index.mjs"),
         modRes,
         "utf8"
       );

--- a/packages/react-icons/scripts/task_common.ts
+++ b/packages/react-icons/scripts/task_common.ts
@@ -72,7 +72,7 @@ export default m
     "utf8"
   );
   await fs.appendFile(
-    path.resolve(DIST, "index.esm.js"),
+    path.resolve(DIST, "index.mjs"),
     generateEntryMjs(),
     "utf8"
   );

--- a/packages/react-icons/scripts/task_files.ts
+++ b/packages/react-icons/scripts/task_files.ts
@@ -26,7 +26,7 @@ export async function dirInit({ DIST, LIB, rootDir }) {
   const write = (filePath, str) =>
     fs.writeFile(path.resolve(DIST, ...filePath), str, "utf8").catch(ignore);
 
-  const initFiles = ["index.d.ts", "index.esm.js", "index.js"];
+  const initFiles = ["index.d.ts", "index.mjs", "index.js"];
 
   for (const icon of icons) {
     await fs.mkdir(path.resolve(DIST, icon.id)).catch(ignore);
@@ -62,12 +62,12 @@ export async function writeIconModuleFiles(
       if (exists.has(name)) continue;
       exists.add(name);
 
-      // write like: module/fa/FaBeer.esm.js
+      // write like: module/fa/FaBeer.mjs
       const modRes = iconRowTemplate(icon, name, iconData, "module");
       const modHeader =
         "// THIS FILE IS AUTO GENERATED\nimport { GenIcon } from '../lib';\n";
       await fs.writeFile(
-        path.resolve(DIST, icon.id, `${name}.esm.js`),
+        path.resolve(DIST, icon.id, `${name}.mjs`),
         modHeader + modRes,
         "utf8"
       );


### PR DESCRIPTION
This fixes #717 by adding support for ESM in Node.js, additionally, it removes the `module` key as a way of determining the module type as [it's not officially supported by Node.js](https://stackoverflow.com/questions/42708484/what-is-the-module-package-json-field-for#:~:text=The%20module%20field%20is%20not%20officially%20defined%20by%20Node.js%20and%20support%20is%20not%20planned.%20Instead%2C%20the%20Node.js%20community%20settled%20on%20package%20exports%20which%20they%20believe%20is%20more%20versatile.)