### PR TITLE
feat: Keyboard Shortcut to focus directly on search input field

### DIFF
--- a/packages/preview/src/styles/_components.scss
+++ b/packages/preview/src/styles/_components.scss
@@ -59,7 +59,7 @@ a {
   input {
     width: 100%;
     line-height: 1.8rem;
-    font-size: 1.2rem;
+    font-size: 1.1rem;
     color: var(--color-black);
     border-radius: var(--border-radius-md);
     border: 2px solid var(--color-gray-3);

--- a/packages/react-icons/VERSIONS
+++ b/packages/react-icons/VERSIONS
@@ -9,7 +9,7 @@
 | [Typicons](http://s-ings.com/typicons/) | [CC BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/) | 2.1.2 | 336 |
 | [Github Octicons icons](https://octicons.github.com/) | [MIT](https://github.com/primer/octicons/blob/master/LICENSE) | 18.3.0 | 264 |
 | [Feather](https://feathericons.com/) | [MIT](https://github.com/feathericons/feather/blob/master/LICENSE) | 4.28.0 | 286 |
-| [Lucide](https://lucide.dev/) | [ISC](https://github.com/lucide-icons/lucide/blob/main/LICENSE) | v4.8.1-snapshot.2-18-gf29c8065 | 1042 |
+| [Lucide](https://lucide.dev/) | [ISC](https://github.com/lucide-icons/lucide/blob/main/LICENSE) | 29f870de511eb39238f38a5671e2013f1aecf33a | 1042 |
 | [Game Icons](https://game-icons.net/) | [CC BY 3.0](https://creativecommons.org/licenses/by/3.0/) | 12920d6565588f0512542a3cb0cdfd36a497f910 | 4040 |
 | [Weather Icons](https://erikflowers.github.io/weather-icons/) | [SIL OFL 1.1](http://scripts.sil.org/OFL) | 2.0.12 | 219 |
 | [Devicons](https://vorillaz.github.io/devicons/) | [MIT](https://opensource.org/licenses/MIT) | 1.8.0 | 192 |


### PR DESCRIPTION
issue #797 

People around me also thought it would be great for the React Icon website to have this feature, so I implemented this

- widow and others
<img width="203" alt="shortcut01" src="https://github.com/react-icons/react-icons/assets/60560836/74ec3094-6015-482d-913f-97fbfaa87036">

- macOs
<img width="204" alt="shortcut02" src="https://github.com/react-icons/react-icons/assets/60560836/a71e9cc7-4fb6-417c-b27e-952595c9205c">


note
- I changed the font size of the search input to 1.1em to display the shortcut key in it. 

** I tested this feature on the site locally and it all worked fine **

