### PR TITLE
Add Core Solid icons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ lib
 module
 *.log
 *.tgz
+.idea
 
 .pnp.*
 .yarn/*

--- a/packages/react-icons/VERSIONS
+++ b/packages/react-icons/VERSIONS
@@ -31,3 +31,4 @@
 | [Radix Icons](https://icons.radix-ui.com) | [MIT](https://github.com/radix-ui/icons/blob/master/LICENSE) | @radix-ui/react-icons@1.3.0-1-g94b3fcf | 318 |
 | [Phosphor Icons](https://github.com/phosphor-icons/core) | [MIT](https://github.com/phosphor-icons/core/blob/main/LICENSE) | 2.0.2 | 7488 |
 | [Icons8 Line Awesome](https://icons8.com/line-awesome) | [MIT](https://github.com/icons8/line-awesome/blob/master/LICENSE.md) | 1.3.1 | 1544 |
+| [Streamline: Core Solid](https://www.streamlinehq.com/) | [CC BY 4.0 License](https://creativecommons.org/licenses/by/4.0/) | 1.0 | 1000 |

--- a/packages/react-icons/src/icons/index.ts
+++ b/packages/react-icons/src/icons/index.ts
@@ -786,4 +786,29 @@ export const icons: IconDefinition[] = [
       hash: "78a101217707c9b1c4dcf2a821be75684e36307f",
     },
   },
+  {
+    id: "stcs",
+    name: "Streamline: Core Solid",
+    contents: [
+      {
+        files: path.resolve(
+            __dirname,
+            "../../icons/streamline-core-solid/core/solid/**/*.svg"
+        ),
+        formatter: (name) => `StCS${name}`,
+        processWithSVGO: true,
+      },
+    ],
+    projectUrl: "https://www.streamlinehq.com",
+    license: "CC BY 4.0 License",
+    licenseUrl: "https://creativecommons.org/licenses/by/4.0/",
+    source: {
+      type: "git",
+      localName: "streamline-core-solid",
+      remoteDir: "core/solid/",
+      url: "https://github.com/webalys-hq/streamline-vectors.git",
+      branch: "main",
+      hash: "4a2b4bae972606cdac5f0e03d96c9785ff566545",
+    },
+  },
 ];


### PR DESCRIPTION
This PR adds 1000 Core Solid icons from [Streamline](https://www.streamlinehq.com/).
Repo source: https://github.com/webalys-hq/streamline-vectors.

This is how it looks in the preview:
<img width="1728" alt="Screenshot 2023-11-07 at 1 03 39 PM" src="https://github.com/react-icons/react-icons/assets/1615659/dfb6a415-d4ad-4fe2-a9e5-314ea0989660">

Please let me know if any changes are needed, I will make them ASAP so that this icon set is published.
