### PR TITLE
Fix: Resolve Import Code Text Responsiveness in Icon Details Modal on Smaller Screens

### DIFF
--- a/packages/preview-astro/src/styles/_components.scss
+++ b/packages/preview-astro/src/styles/_components.scss
@@ -345,6 +345,7 @@ html:has(.modal-root.active) {
     padding: 25px;
   }
   pre {
+    overflow: auto;
     background-color: #24292e;
     color: #e1e4e8;
     padding: 10px;


### PR DESCRIPTION
### Description

Addresses the responsiveness issue of the import code text in the icon details modal on smaller screens. The problem was reported in issue  #849 

### Changes Made
- Modified the CSS in `.icon-detail-modal-content` to ensure proper responsiveness.

### Screenshots
<img width="286" alt="스크린샷 2023-11-22 오후 6 26 32" src="https://github.com/react-icons/react-icons/assets/33623123/12d5ab13-9bd8-4886-95b3-b4a5b7e64963">


### Request for Review
@kamijin-fanta @gorangajic  Could you please review this pull request?