### PR TITLE
[feature]: remove the icon set version information from the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,13 @@ function Question() {
 ## Icons
 
 | Icon Library                                                            | License                                                                                           |  Count |
-| ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- | ---------------------------------------- | ----: |
+| ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- | ---------------------------------------- |
 | [Circum Icons](https://circumicons.com/)                                | [MPL-2.0 license](https://github.com/Klarr-Agency/Circum-Icons/blob/main/LICENSE)                 |   288 |
 | [Font Awesome 5](https://fontawesome.com/)                              | [CC BY 4.0 License](https://creativecommons.org/licenses/by/4.0/)                                 |  1612 |
 | [Font Awesome 6](https://fontawesome.com/)                              | [CC BY 4.0 License](https://creativecommons.org/licenses/by/4.0/)                                 |  2020 |
 | [Ionicons 4](https://ionicons.com/)                                     | [MIT](https://github.com/ionic-team/ionicons/blob/master/LICENSE)                                 |   696 |
 | [Ionicons 5](https://ionicons.com/)                                     | [MIT](https://github.com/ionic-team/ionicons/blob/master/LICENSE)                                 |  1332 |
-| [Material Design icons](http://google.github.io/material-design-icons/) | [Apache License Version 2.0](https://github.com/google/material-design-icons/blob/master/LICENSE) | 4.0.0-61-g511eea577b                     |  4341 |
+| [Material Design icons](http://google.github.io/material-design-icons/) | [Apache License Version 2.0](https://github.com/google/material-design-icons/blob/master/LICENSE) |  4341 |
 | [Typicons](http://s-ings.com/typicons/)                                 | [CC BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/)                                   |   336 |
 | [Github Octicons icons](https://octicons.github.com/)                   | [MIT](https://github.com/primer/octicons/blob/master/LICENSE)                                     |   264 |
 | [Feather](https://feathericons.com/)                                    | [MIT](https://github.com/feathericons/feather/blob/master/LICENSE)                                |   286 |
@@ -98,7 +98,7 @@ function Question() {
 | [Themify Icons](https://github.com/lykmapipo/themify-icons)             | [MIT](https://github.com/thecreation/standard-icons/blob/master/modules/themify-icons/LICENSE)    |   352 |
 | [Radix Icons](https://icons.radix-ui.com)                               | [MIT](https://github.com/radix-ui/icons/blob/master/LICENSE)                                      |   318 |
 | [Phosphor Icons](https://github.com/phosphor-icons/core)                | [MIT](https://github.com/phosphor-icons/core/blob/main/LICENSE)                                   |  7488 |
-| [Icons8 Line Awesome](https://icons8.com/line-awesome)                  | [MIT](https://github.com/icons8/line-awesome/blob/master/LICENSE.md)                              | 1544 |
+| [Icons8 Line Awesome](https://icons8.com/line-awesome)                  | [MIT](https://github.com/icons8/line-awesome/blob/master/LICENSE.md)                              | 1544  |
 
 You can find the icon set versions in packages/react-icons/VERSIOMS.
 You can add more icons by submitting pull requests or creating issues.

--- a/README.md
+++ b/README.md
@@ -66,40 +66,41 @@ function Question() {
 
 ## Icons
 
-| Icon Library                                                            | License                                                                                           | Version                                  | Count |
+| Icon Library                                                            | License                                                                                           |  Count |
 | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- | ---------------------------------------- | ----: |
-| [Circum Icons](https://circumicons.com/)                                | [MPL-2.0 license](https://github.com/Klarr-Agency/Circum-Icons/blob/main/LICENSE)                 | 1.0.0                                    |   288 |
-| [Font Awesome 5](https://fontawesome.com/)                              | [CC BY 4.0 License](https://creativecommons.org/licenses/by/4.0/)                                 | 5.15.4-3-gafecf2a                        |  1612 |
-| [Font Awesome 6](https://fontawesome.com/)                              | [CC BY 4.0 License](https://creativecommons.org/licenses/by/4.0/)                                 | 6.4.0                                    |  2020 |
-| [Ionicons 4](https://ionicons.com/)                                     | [MIT](https://github.com/ionic-team/ionicons/blob/master/LICENSE)                                 | 4.6.3                                    |   696 |
-| [Ionicons 5](https://ionicons.com/)                                     | [MIT](https://github.com/ionic-team/ionicons/blob/master/LICENSE)                                 | 5.5.0                                    |  1332 |
+| [Circum Icons](https://circumicons.com/)                                | [MPL-2.0 license](https://github.com/Klarr-Agency/Circum-Icons/blob/main/LICENSE)                 |   288 |
+| [Font Awesome 5](https://fontawesome.com/)                              | [CC BY 4.0 License](https://creativecommons.org/licenses/by/4.0/)                                 |  1612 |
+| [Font Awesome 6](https://fontawesome.com/)                              | [CC BY 4.0 License](https://creativecommons.org/licenses/by/4.0/)                                 |  2020 |
+| [Ionicons 4](https://ionicons.com/)                                     | [MIT](https://github.com/ionic-team/ionicons/blob/master/LICENSE)                                 |   696 |
+| [Ionicons 5](https://ionicons.com/)                                     | [MIT](https://github.com/ionic-team/ionicons/blob/master/LICENSE)                                 |  1332 |
 | [Material Design icons](http://google.github.io/material-design-icons/) | [Apache License Version 2.0](https://github.com/google/material-design-icons/blob/master/LICENSE) | 4.0.0-61-g511eea577b                     |  4341 |
-| [Typicons](http://s-ings.com/typicons/)                                 | [CC BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/)                                   | 2.1.2                                    |   336 |
-| [Github Octicons icons](https://octicons.github.com/)                   | [MIT](https://github.com/primer/octicons/blob/master/LICENSE)                                     | 18.3.0                                   |   264 |
-| [Feather](https://feathericons.com/)                                    | [MIT](https://github.com/feathericons/feather/blob/master/LICENSE)                                | 4.28.0                                   |   286 |
-| [Lucide](https://lucide.dev/)                                           | [ISC](https://github.com/lucide-icons/lucide/blob/main/LICENSE)                                   | v4.8.1-snapshot.2-15-g29448c1c           |  1042 |
-| [Game Icons](https://game-icons.net/)                                   | [CC BY 3.0](https://creativecommons.org/licenses/by/3.0/)                                         | 12920d6565588f0512542a3cb0cdfd36a497f910 |  4040 |
-| [Weather Icons](https://erikflowers.github.io/weather-icons/)           | [SIL OFL 1.1](http://scripts.sil.org/OFL)                                                         | 2.0.12                                   |   219 |
-| [Devicons](https://vorillaz.github.io/devicons/)                        | [MIT](https://opensource.org/licenses/MIT)                                                        | 1.8.0                                    |   192 |
-| [Ant Design Icons](https://github.com/ant-design/ant-design-icons)      | [MIT](https://opensource.org/licenses/MIT)                                                        | 4.2.1                                    |   789 |
-| [Bootstrap Icons](https://github.com/twbs/icons)                        | [MIT](https://opensource.org/licenses/MIT)                                                        | 1.10.3                                   |  2592 |
-| [Remix Icon](https://github.com/Remix-Design/RemixIcon)                 | [Apache License Version 2.0](http://www.apache.org/licenses/)                                     | 2.5.0                                    |  2271 |
-| [Flat Color Icons](https://github.com/icons8/flat-color-icons)          | [MIT](https://opensource.org/licenses/MIT)                                                        | 1.0.2                                    |   329 |
-| [Grommet-Icons](https://github.com/grommet/grommet-icons)               | [Apache License Version 2.0](http://www.apache.org/licenses/)                                     | 4.9.0                                    |   620 |
-| [Heroicons](https://github.com/tailwindlabs/heroicons)                  | [MIT](https://opensource.org/licenses/MIT)                                                        | 1.0.6                                    |   460 |
-| [Heroicons 2](https://github.com/tailwindlabs/heroicons)                | [MIT](https://opensource.org/licenses/MIT)                                                        | 2.0.17                                   |   876 |
-| [Simple Icons](https://simpleicons.org/)                                | [CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/)                           | 8.6.0                                    |  2437 |
-| [Simple Line Icons](https://thesabbir.github.io/simple-line-icons/)     | [MIT](https://opensource.org/licenses/MIT)                                                        | 2.5.5                                    |   189 |
-| [IcoMoon Free](https://github.com/Keyamoon/IcoMoon-Free)                | [CC BY 4.0 License](https://github.com/Keyamoon/IcoMoon-Free/blob/master/License.txt)             | d006795ede82361e1bac1ee76f215cf1dc51e4ca |   491 |
-| [BoxIcons](https://github.com/atisawd/boxicons)                         | [CC BY 4.0 License](https://github.com/atisawd/boxicons/blob/master/LICENSE)                      | 2.1.4                                    |  1634 |
-| [css.gg](https://github.com/astrit/css.gg)                              | [MIT](https://opensource.org/licenses/MIT)                                                        | 2.0.0                                    |   704 |
-| [VS Code Icons](https://github.com/microsoft/vscode-codicons)           | [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)                                         | 0.0.32                                   |   423 |
-| [Tabler Icons](https://github.com/tabler/tabler-icons)                  | [MIT](https://opensource.org/licenses/MIT)                                                        | 2.7.0                                    |  3455 |
-| [Themify Icons](https://github.com/lykmapipo/themify-icons)             | [MIT](https://github.com/thecreation/standard-icons/blob/master/modules/themify-icons/LICENSE)    | v0.1.2-2-g9600186                        |   352 |
-| [Radix Icons](https://icons.radix-ui.com)                               | [MIT](https://github.com/radix-ui/icons/blob/master/LICENSE)                                      | @modulz/generate-icon-lib@0.2.1          |   318 |
-| [Phosphor Icons](https://github.com/phosphor-icons/core)                | [MIT](https://github.com/phosphor-icons/core/blob/main/LICENSE)                                   | 2.0.2                                    |  7488 |
-| [Icons8 Line Awesome](https://icons8.com/line-awesome)                  | [MIT](https://github.com/icons8/line-awesome/blob/master/LICENSE.md)                              | 1.2.1                                    |  1544 |
+| [Typicons](http://s-ings.com/typicons/)                                 | [CC BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/)                                   |   336 |
+| [Github Octicons icons](https://octicons.github.com/)                   | [MIT](https://github.com/primer/octicons/blob/master/LICENSE)                                     |   264 |
+| [Feather](https://feathericons.com/)                                    | [MIT](https://github.com/feathericons/feather/blob/master/LICENSE)                                |   286 |
+| [Lucide](https://lucide.dev/)                                           | [ISC](https://github.com/lucide-icons/lucide/blob/main/LICENSE)                                   |  1042 |
+| [Game Icons](https://game-icons.net/)                                   | [CC BY 3.0](https://creativecommons.org/licenses/by/3.0/)                                         |  4040 |
+| [Weather Icons](https://erikflowers.github.io/weather-icons/)           | [SIL OFL 1.1](http://scripts.sil.org/OFL)                                                         |   219 |
+| [Devicons](https://vorillaz.github.io/devicons/)                        | [MIT](https://opensource.org/licenses/MIT)                                                        |   192 |
+| [Ant Design Icons](https://github.com/ant-design/ant-design-icons)      | [MIT](https://opensource.org/licenses/MIT)                                                        |   789 |
+| [Bootstrap Icons](https://github.com/twbs/icons)                        | [MIT](https://opensource.org/licenses/MIT)                                                        |  2592 |
+| [Remix Icon](https://github.com/Remix-Design/RemixIcon)                 | [Apache License Version 2.0](http://www.apache.org/licenses/)                                     |  2271 |
+| [Flat Color Icons](https://github.com/icons8/flat-color-icons)          | [MIT](https://opensource.org/licenses/MIT)                                                        |   329 |
+| [Grommet-Icons](https://github.com/grommet/grommet-icons)               | [Apache License Version 2.0](http://www.apache.org/licenses/)                                     |   620 |
+| [Heroicons](https://github.com/tailwindlabs/heroicons)                  | [MIT](https://opensource.org/licenses/MIT)                                                        |   460 |
+| [Heroicons 2](https://github.com/tailwindlabs/heroicons)                | [MIT](https://opensource.org/licenses/MIT)                                                        |   876 |
+| [Simple Icons](https://simpleicons.org/)                                | [CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/)                           |  2437 |
+| [Simple Line Icons](https://thesabbir.github.io/simple-line-icons/)     | [MIT](https://opensource.org/licenses/MIT)                                                        |   189 |
+| [IcoMoon Free](https://github.com/Keyamoon/IcoMoon-Free)                | [CC BY 4.0 License](https://github.com/Keyamoon/IcoMoon-Free/blob/master/License.txt)             |   491 |
+| [BoxIcons](https://github.com/atisawd/boxicons)                         | [CC BY 4.0 License](https://github.com/atisawd/boxicons/blob/master/LICENSE)                      |  1634 |
+| [css.gg](https://github.com/astrit/css.gg)                              | [MIT](https://opensource.org/licenses/MIT)                                                        |   704 |
+| [VS Code Icons](https://github.com/microsoft/vscode-codicons)           | [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)                                         |   423 |
+| [Tabler Icons](https://github.com/tabler/tabler-icons)                  | [MIT](https://opensource.org/licenses/MIT)                                                        |  3455 |
+| [Themify Icons](https://github.com/lykmapipo/themify-icons)             | [MIT](https://github.com/thecreation/standard-icons/blob/master/modules/themify-icons/LICENSE)    |   352 |
+| [Radix Icons](https://icons.radix-ui.com)                               | [MIT](https://github.com/radix-ui/icons/blob/master/LICENSE)                                      |   318 |
+| [Phosphor Icons](https://github.com/phosphor-icons/core)                | [MIT](https://github.com/phosphor-icons/core/blob/main/LICENSE)                                   |  7488 |
+| [Icons8 Line Awesome](https://icons8.com/line-awesome)                  | [MIT](https://github.com/icons8/line-awesome/blob/master/LICENSE.md)                              | 1544 |
 
+You can find the icon set versions in packages/react-icons/VERSIOMS.
 You can add more icons by submitting pull requests or creating issues.
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ function Question() {
 | [Icons8 Line Awesome](https://icons8.com/line-awesome)                  | [MIT](https://github.com/icons8/line-awesome/blob/master/LICENSE.md)                              | 1544  |
 
 You can find the icon set versions in packages/react-icons/VERSIOMS.
+
 You can add more icons by submitting pull requests or creating issues.
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ function Question() {
 
 ## Icons
 
-| Icon Library                                                            | License                                                                                           |  Count |
-| ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- | -----: |
+| Icon Library                                                            | License                                                                                           | Count |
+| ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- | ----: |
 | [Circum Icons](https://circumicons.com/)                                | [MPL-2.0 license](https://github.com/Klarr-Agency/Circum-Icons/blob/main/LICENSE)                 |   288 |
 | [Font Awesome 5](https://fontawesome.com/)                              | [CC BY 4.0 License](https://creativecommons.org/licenses/by/4.0/)                                 |  1612 |
 | [Font Awesome 6](https://fontawesome.com/)                              | [CC BY 4.0 License](https://creativecommons.org/licenses/by/4.0/)                                 |  2020 |
@@ -98,7 +98,7 @@ function Question() {
 | [Themify Icons](https://github.com/lykmapipo/themify-icons)             | [MIT](https://github.com/thecreation/standard-icons/blob/master/modules/themify-icons/LICENSE)    |   352 |
 | [Radix Icons](https://icons.radix-ui.com)                               | [MIT](https://github.com/radix-ui/icons/blob/master/LICENSE)                                      |   318 |
 | [Phosphor Icons](https://github.com/phosphor-icons/core)                | [MIT](https://github.com/phosphor-icons/core/blob/main/LICENSE)                                   |  7488 |
-| [Icons8 Line Awesome](https://icons8.com/line-awesome)                  | [MIT](https://github.com/icons8/line-awesome/blob/master/LICENSE.md)                              | 1544  |
+| [Icons8 Line Awesome](https://icons8.com/line-awesome)                  | [MIT](https://github.com/icons8/line-awesome/blob/master/LICENSE.md)                              |  1544 |
 
 You can find the icon set versions in packages/react-icons/VERSIOMS.
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ function Question() {
 ## Icons
 
 | Icon Library                                                            | License                                                                                           |  Count |
-| ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- | ---------------------------------------- |
+| ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- | -----: |
 | [Circum Icons](https://circumicons.com/)                                | [MPL-2.0 license](https://github.com/Klarr-Agency/Circum-Icons/blob/main/LICENSE)                 |   288 |
 | [Font Awesome 5](https://fontawesome.com/)                              | [CC BY 4.0 License](https://creativecommons.org/licenses/by/4.0/)                                 |  1612 |
 | [Font Awesome 6](https://fontawesome.com/)                              | [CC BY 4.0 License](https://creativecommons.org/licenses/by/4.0/)                                 |  2020 |

--- a/packages/demo-all-files/public/index.html
+++ b/packages/demo-all-files/public/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />

--- a/packages/demo-all-files/src/registerServiceWorker.js
+++ b/packages/demo-all-files/src/registerServiceWorker.js
@@ -14,8 +14,8 @@ const isLocalhost = Boolean(
     window.location.hostname === "[::1]" ||
     // 127.0.0.1/8 is considered localhost for IPv4.
     window.location.hostname.match(
-      /^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/
-    )
+      /^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/,
+    ),
 );
 
 export default function register() {
@@ -41,7 +41,7 @@ export default function register() {
         navigator.serviceWorker.ready.then(() => {
           console.log(
             "This web app is being served cache-first by a service " +
-              "worker. To learn more, visit https://goo.gl/SC7cgQ"
+              "worker. To learn more, visit https://goo.gl/SC7cgQ",
           );
         });
       } else {
@@ -103,7 +103,7 @@ function checkValidServiceWorker(swUrl) {
     })
     .catch(() => {
       console.log(
-        "No internet connection found. App is running in offline mode."
+        "No internet connection found. App is running in offline mode.",
       );
     });
 }

--- a/packages/demo/public/index.html
+++ b/packages/demo/public/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />

--- a/packages/demo/src/registerServiceWorker.js
+++ b/packages/demo/src/registerServiceWorker.js
@@ -14,8 +14,8 @@ const isLocalhost = Boolean(
     window.location.hostname === "[::1]" ||
     // 127.0.0.1/8 is considered localhost for IPv4.
     window.location.hostname.match(
-      /^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/
-    )
+      /^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/,
+    ),
 );
 
 export default function register() {
@@ -41,7 +41,7 @@ export default function register() {
         navigator.serviceWorker.ready.then(() => {
           console.log(
             "This web app is being served cache-first by a service " +
-              "worker. To learn more, visit https://goo.gl/SC7cgQ"
+              "worker. To learn more, visit https://goo.gl/SC7cgQ",
           );
         });
       } else {
@@ -103,7 +103,7 @@ function checkValidServiceWorker(swUrl) {
     })
     .catch(() => {
       console.log(
-        "No internet connection found. App is running in offline mode."
+        "No internet connection found. App is running in offline mode.",
       );
     });
 }

--- a/packages/preview/next.config.js
+++ b/packages/preview/next.config.js
@@ -25,7 +25,7 @@ module.exports = withPWA({
     }
     config.resolve.alias["@components"] = path.join(
       __dirname,
-      `src/components`
+      `src/components`,
     );
     config.resolve.alias["@pages"] = path.join(__dirname, `src/pages`);
     config.resolve.alias["@styles"] = path.join(__dirname, `src/styles`);

--- a/packages/preview/src/components/@core/sidebar/index.tsx
+++ b/packages/preview/src/components/@core/sidebar/index.tsx
@@ -10,7 +10,7 @@ const searchPath = "/search";
 export default function Sidebar() {
   const iconsList = useMemo(
     () => ALL_ICONS.sort((a, b) => (a.name > b.name ? 1 : -1)),
-    []
+    [],
   );
   const router = useRouter();
   const [isOpen, setIsOpen] = useState(false);
@@ -26,7 +26,7 @@ export default function Sidebar() {
     debounce((query: string) => {
       router.push({ pathname: searchPath, query: query ? { q: query } : null });
     }, 500),
-    []
+    [],
   );
 
   const onSearch = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/packages/preview/src/components/pages/search/search-iconset.tsx
+++ b/packages/preview/src/components/pages/search/search-iconset.tsx
@@ -12,7 +12,7 @@ export default function SearchIconSet({ icon, query, highlightPattern }) {
     <IconSet fallback={<SearchPageIconLoading />}>
       {({ default: icons }) => {
         const found = Object.keys(icons).filter((name) =>
-          name.toLowerCase().includes(query)
+          name.toLowerCase().includes(query),
         );
         return (
           <>

--- a/packages/preview/src/styles/_components.scss
+++ b/packages/preview/src/styles/_components.scss
@@ -167,7 +167,8 @@ a {
       justify-content: center;
       background: var(--color-white);
       border-radius: var(--border-radius-md);
-      box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1),
+      box-shadow:
+        0 1px 3px 0 rgba(0, 0, 0, 0.1),
         0 1px 2px 0 rgba(0, 0, 0, 0.06);
       border: 2px solid transparent;
       font-size: 1.6em;

--- a/packages/preview/src/utils/debounce.ts
+++ b/packages/preview/src/utils/debounce.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function debounce<T extends (...args: any[]) => any>(
   callback: T,
-  delay: number
+  delay: number,
 ): (...args: Parameters<T>) => void {
   let timeoutId: ReturnType<typeof setTimeout>;
 

--- a/packages/react-icons/plugin/defaultImportConverter.js
+++ b/packages/react-icons/plugin/defaultImportConverter.js
@@ -6,7 +6,7 @@ module.exports = (babel, options) => {
         var spec = path.node.specifiers.map((spec) =>
           options.keys.includes(spec.local.name)
             ? babel.types.ImportDefaultSpecifier(spec.local)
-            : spec
+            : spec,
         );
         path.node.specifiers = spec;
       },

--- a/packages/react-icons/scripts/build.ts
+++ b/packages/react-icons/scripts/build.ts
@@ -34,7 +34,7 @@ async function main() {
     });
     await task("@react-icons/all write icons", async () => {
       await Promise.all(
-        icons.map((icon) => taskAll.writeIconModule(icon, allOpt))
+        icons.map((icon) => taskAll.writeIconModule(icon, allOpt)),
       );
     });
 
@@ -51,13 +51,13 @@ async function main() {
       await taskCommon.writeLicense(filesOpt);
       await taskCommon.writePackageJson(
         { name: "@react-icons/all-files" },
-        filesOpt
+        filesOpt,
       );
       await taskCommon.copyReadme(filesOpt);
     });
     await task("@react-icons/all-files write icons", async () => {
       await Promise.all(
-        icons.map((icon) => taskFiles.writeIconModuleFiles(icon, filesOpt))
+        icons.map((icon) => taskFiles.writeIconModuleFiles(icon, filesOpt)),
       );
     });
 

--- a/packages/react-icons/scripts/check.ts
+++ b/packages/react-icons/scripts/check.ts
@@ -41,14 +41,14 @@ async function main() {
 
 async function gitDiffCount(
   source: IconSetGitSource,
-  ctx: Context
+  ctx: Context,
 ): Promise<{ current: string; diffs: number }> {
   const hashRes = await execFile(
     "git",
     ["rev-parse", `origin/${source.branch}`],
     {
       cwd: ctx.iconDir(source.localName),
-    }
+    },
   );
   const currentHash = hashRes.stdout.trim();
 
@@ -57,7 +57,7 @@ async function gitDiffCount(
     ["rev-list", "--count", `${source.hash}..${currentHash}`],
     {
       cwd: ctx.iconDir(source.localName),
-    }
+    },
   );
 
   return {

--- a/packages/react-icons/scripts/fetcher.ts
+++ b/packages/react-icons/scripts/fetcher.ts
@@ -44,14 +44,14 @@ async function main() {
 
 async function gitCloneIcon(source: IconSetGitSource, ctx: Context) {
   console.log(
-    `start clone icon: ${source.url}/${source.remoteDir}@${source.branch}`
+    `start clone icon: ${source.url}/${source.remoteDir}@${source.branch}`,
   );
   await execFile(
     "git",
     ["clone", "--filter=tree:0", "--no-checkout", source.url, source.localName],
     {
       cwd: ctx.distBaseDir,
-    }
+    },
   );
 
   await execFile(
@@ -59,7 +59,7 @@ async function gitCloneIcon(source: IconSetGitSource, ctx: Context) {
     ["sparse-checkout", "set", "--cone", "--skip-checks", source.remoteDir],
     {
       cwd: ctx.iconDir(source.localName),
-    }
+    },
   );
 
   await execFile("git", ["checkout", source.hash], {

--- a/packages/react-icons/scripts/logics.ts
+++ b/packages/react-icons/scripts/logics.ts
@@ -21,7 +21,7 @@ export async function convertIconData(svg, multiColor) {
   // 2. convert to camelcase ex: fill-opacity => fillOpacity
   const attrConverter = (
     /** @type {{[key: string]: string}} */ attribs,
-    /** @type string */ tagName
+    /** @type string */ tagName,
   ) =>
     attribs &&
     Object.keys(attribs)
@@ -32,7 +32,7 @@ export async function convertIconData(svg, multiColor) {
             ...(tagName === "svg"
               ? ["xmlns", "xmlns:xlink", "xml:space", "width", "height"]
               : []), // if tagName is svg remove size attributes
-          ].includes(name)
+          ].includes(name),
       )
       .reduce((obj, name) => {
         const newName = name.startsWith("aria-") ? name : camelcase(name);

--- a/packages/react-icons/scripts/task_all.ts
+++ b/packages/react-icons/scripts/task_all.ts
@@ -29,15 +29,15 @@ export async function dirInit({ DIST, LIB, rootDir }) {
 
     await write(
       [icon.id, "index.js"],
-      "// THIS FILE IS AUTO GENERATED\nvar GenIcon = require('../lib').GenIcon\n"
+      "// THIS FILE IS AUTO GENERATED\nvar GenIcon = require('../lib').GenIcon\n",
     );
     await write(
       [icon.id, "index.esm.js"],
-      "// THIS FILE IS AUTO GENERATED\nimport { GenIcon } from '../lib';\n"
+      "// THIS FILE IS AUTO GENERATED\nimport { GenIcon } from '../lib';\n",
     );
     await write(
       [icon.id, "index.d.ts"],
-      "// THIS FILE IS AUTO GENERATED\nimport { IconTree, IconType } from '../lib'\n"
+      "// THIS FILE IS AUTO GENERATED\nimport { IconTree, IconType } from '../lib'\n",
     );
     await write(
       [icon.id, "package.json"],
@@ -47,8 +47,8 @@ export async function dirInit({ DIST, LIB, rootDir }) {
           module: "./index.esm.js",
         },
         null,
-        2
-      ) + "\n"
+        2,
+      ) + "\n",
     );
   }
 
@@ -83,19 +83,19 @@ export async function writeIconModule(icon, { DIST, LIB, rootDir }) {
       await fs.appendFile(
         path.resolve(DIST, icon.id, "index.esm.js"),
         modRes,
-        "utf8"
+        "utf8",
       );
       const comRes = iconRowTemplate(icon, name, iconData, "common");
       await fs.appendFile(
         path.resolve(DIST, icon.id, "index.js"),
         comRes,
-        "utf8"
+        "utf8",
       );
       const dtsRes = iconRowTemplate(icon, name, iconData, "dts");
       await fs.appendFile(
         path.resolve(DIST, icon.id, "index.d.ts"),
         dtsRes,
-        "utf8"
+        "utf8",
       );
 
       exists.add(file);

--- a/packages/react-icons/scripts/task_common.ts
+++ b/packages/react-icons/scripts/task_common.ts
@@ -21,20 +21,20 @@ export async function writeIconsManifest({ DIST, LIB, rootDir }) {
   await fs.writeFile(
     path.resolve(LIB, "esm", "iconsManifest.js"),
     `export var IconsManifest = ${manifest}`,
-    "utf8"
+    "utf8",
   );
   await fs.writeFile(
     path.resolve(LIB, "cjs", "iconsManifest.js"),
     `module.exports.IconsManifest = ${manifest}`,
-    "utf8"
+    "utf8",
   );
   await fs.copyFile(
     "src/iconsManifest.d.ts",
-    path.resolve(LIB, "esm", "iconsManifest.d.ts")
+    path.resolve(LIB, "esm", "iconsManifest.d.ts"),
   );
   await fs.copyFile(
     "src/iconsManifest.d.ts",
-    path.resolve(LIB, "cjs", "iconsManifest.d.ts")
+    path.resolve(LIB, "cjs", "iconsManifest.d.ts"),
   );
   await fs.copyFile("src/package.json", path.resolve(LIB, "package.json"));
 }
@@ -46,13 +46,13 @@ export async function writeLicense({ DIST, LIB, rootDir }) {
         [
           `${icon.name} - ${icon.projectUrl}`,
           `License: ${icon.license} ${icon.licenseUrl}`,
-        ].join("\n")
+        ].join("\n"),
       )
       .join("\n\n") + "\n";
 
   await fs.copyFile(
     path.resolve(rootDir, "LICENSE_HEADER"),
-    path.resolve(DIST, "LICENSE")
+    path.resolve(DIST, "LICENSE"),
   );
   await fs.appendFile(path.resolve(DIST, "LICENSE"), iconLicenses, "utf8");
 }
@@ -69,17 +69,17 @@ export default m
   await fs.appendFile(
     path.resolve(DIST, "index.js"),
     generateEntryCjs(),
-    "utf8"
+    "utf8",
   );
   await fs.appendFile(
     path.resolve(DIST, "index.esm.js"),
     generateEntryMjs(),
-    "utf8"
+    "utf8",
   );
   await fs.appendFile(
     path.resolve(DIST, "index.d.ts"),
     generateEntryMjs("index.d.ts"),
-    "utf8"
+    "utf8",
   );
 }
 
@@ -113,7 +113,7 @@ export async function writeIconVersions({ DIST, LIB, rootDir }) {
         `git describe --tags || git rev-parse HEAD`,
         {
           cwd: firstDir,
-        }
+        },
       );
       version = stdout.trim();
     }
@@ -128,7 +128,7 @@ export async function writeIconVersions({ DIST, LIB, rootDir }) {
   const emptyVersions = versions.filter((v) => v.count === 0);
   if (emptyVersions.length !== 0) {
     throw Error(
-      `empty icon sets: ${emptyVersions.map((v) => v.icon).join(", ")}`
+      `empty icon sets: ${emptyVersions.map((v) => v.icon).join(", ")}`,
     );
   }
 
@@ -143,7 +143,7 @@ export async function writeIconVersions({ DIST, LIB, rootDir }) {
             `[${v.icon.license}](${v.icon.licenseUrl})`,
             v.version,
             v.count,
-          ].join(" | ")} |`
+          ].join(" | ")} |`,
       )
       .join("\n") +
     "\n";
@@ -154,7 +154,7 @@ export async function writeIconVersions({ DIST, LIB, rootDir }) {
 export async function writePackageJson(override, { DIST, LIB, rootDir }) {
   const packageJsonStr = await fs.readFile(
     path.resolve(rootDir, "package.json"),
-    "utf-8"
+    "utf-8",
   );
   let packageJson = JSON.parse(packageJsonStr);
 
@@ -175,7 +175,7 @@ export async function writePackageJson(override, { DIST, LIB, rootDir }) {
 export async function copyReadme({ DIST, LIB, rootDir }) {
   await fs.copyFile(
     path.resolve(rootDir, "../../README.md"),
-    path.resolve(DIST, "README.md")
+    path.resolve(DIST, "README.md"),
   );
 }
 

--- a/packages/react-icons/scripts/task_files.ts
+++ b/packages/react-icons/scripts/task_files.ts
@@ -39,7 +39,7 @@ export async function dirInit({ DIST, LIB, rootDir }) {
 export async function writeIconModuleFiles(
   icon: IconDefinition,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  { DIST, LIB, rootDir }
+  { DIST, LIB, rootDir },
 ) {
   const exists = new Set(); // for remove duplicate
 
@@ -69,7 +69,7 @@ export async function writeIconModuleFiles(
       await fs.writeFile(
         path.resolve(DIST, icon.id, `${name}.esm.js`),
         modHeader + modRes,
-        "utf8"
+        "utf8",
       );
       const comRes = iconRowTemplate(icon, name, iconData, "common");
       const comHeader =
@@ -77,7 +77,7 @@ export async function writeIconModuleFiles(
       await fs.writeFile(
         path.resolve(DIST, icon.id, `${name}.js`),
         comHeader + comRes,
-        "utf8"
+        "utf8",
       );
       const dtsRes = iconRowTemplate(icon, name, iconData, "dts");
       const dtsHeader =
@@ -85,7 +85,7 @@ export async function writeIconModuleFiles(
       await fs.writeFile(
         path.resolve(DIST, icon.id, `${name}.d.ts`),
         dtsHeader + dtsRes,
-        "utf8"
+        "utf8",
       );
 
       exists.add(file);

--- a/packages/react-icons/scripts/templates.ts
+++ b/packages/react-icons/scripts/templates.ts
@@ -2,7 +2,7 @@ export function iconRowTemplate(
   icon,
   formattedName,
   iconData,
-  type = "module"
+  type = "module",
 ) {
   switch (type) {
     case "module":

--- a/packages/react-icons/src/iconBase.tsx
+++ b/packages/react-icons/src/iconBase.tsx
@@ -15,8 +15,8 @@ function Tree2Element(tree: IconTree[]): React.ReactElement[] {
       React.createElement(
         node.tag,
         { key: i, ...node.attr },
-        Tree2Element(node.child)
-      )
+        Tree2Element(node.child),
+      ),
     )
   );
 }
@@ -38,7 +38,7 @@ export interface IconBaseProps extends React.SVGAttributes<SVGElement> {
 
 export type IconType = (props: IconBaseProps) => JSX.Element;
 export function IconBase(
-  props: IconBaseProps & { attr?: Record<string, string> }
+  props: IconBaseProps & { attr?: Record<string, string> },
 ): JSX.Element {
   const elem = (conf: IconContext) => {
     const { attr, size, title, ...svgProps } = props;

--- a/packages/react-icons/src/icons/index.ts
+++ b/packages/react-icons/src/icons/index.ts
@@ -33,14 +33,14 @@ export const icons: IconDefinition[] = [
       {
         files: path.resolve(
           __dirname,
-          "../../icons/fontawesome/svgs/+(brands|solid)/*.svg"
+          "../../icons/fontawesome/svgs/+(brands|solid)/*.svg",
         ),
         formatter: (name) => `Fa${name}`,
       },
       {
         files: path.resolve(
           __dirname,
-          "../../icons/fontawesome/svgs/regular/*.svg"
+          "../../icons/fontawesome/svgs/regular/*.svg",
         ),
         formatter: (name) => `FaReg${name}`,
       },
@@ -64,14 +64,14 @@ export const icons: IconDefinition[] = [
       {
         files: path.resolve(
           __dirname,
-          "../../icons/fontawesome-6/svgs/+(brands|solid)/*.svg"
+          "../../icons/fontawesome-6/svgs/+(brands|solid)/*.svg",
         ),
         formatter: (name) => `Fa${name}`,
       },
       {
         files: path.resolve(
           __dirname,
-          "../../icons/fontawesome-6/svgs/regular/*.svg"
+          "../../icons/fontawesome-6/svgs/regular/*.svg",
         ),
         formatter: (name) => `FaReg${name}`,
       },
@@ -95,7 +95,7 @@ export const icons: IconDefinition[] = [
       {
         files: path.resolve(
           path.dirname(require.resolve("ionicons")),
-          "collection/icon/svg/*.svg"
+          "collection/icon/svg/*.svg",
         ),
         formatter: (name) => `Io${name}`,
       },
@@ -111,7 +111,7 @@ export const icons: IconDefinition[] = [
       {
         files: path.resolve(
           __dirname,
-          "../../../../node_modules/ionicons-5/dist/svg/*.svg"
+          "../../../../node_modules/ionicons-5/dist/svg/*.svg",
         ),
         formatter: (name) => `Io${name}`,
         processWithSVGO: true,
@@ -130,39 +130,39 @@ export const icons: IconDefinition[] = [
           const normal = await glob(
             path.resolve(
               __dirname,
-              "../../icons/material-design-icons/src/*/*/materialicons/24px.svg"
-            )
+              "../../icons/material-design-icons/src/*/*/materialicons/24px.svg",
+            ),
           );
 
           const twotone = await glob(
             path.resolve(
               __dirname,
-              "../../icons/material-design-icons/src/*/*/materialiconstwotone/24px.svg"
-            )
+              "../../icons/material-design-icons/src/*/*/materialiconstwotone/24px.svg",
+            ),
           );
           return [
             ...normal,
             ...twotone.filter(
-              (file) => !normal.includes(file.replace("twotone/", "/"))
+              (file) => !normal.includes(file.replace("twotone/", "/")),
             ),
           ];
         },
         formatter: (name, file) =>
           `Md${camelcase(
             file.replace(/^.*\/([^/]+)\/materialicons[^/]*\/24px.svg$/i, "$1"),
-            { pascalCase: true }
+            { pascalCase: true },
           )}`,
         processWithSVGO: true,
       },
       {
         files: path.resolve(
           __dirname,
-          "../../icons/material-design-icons/src/*/*/materialiconsoutlined/24px.svg"
+          "../../icons/material-design-icons/src/*/*/materialiconsoutlined/24px.svg",
         ),
         formatter: (name, file) =>
           `MdOutline${camelcase(
             file.replace(/^.*\/([^/]+)\/materialicons[^/]*\/24px.svg$/i, "$1"),
-            { pascalCase: true }
+            { pascalCase: true },
           )}`,
         processWithSVGO: true,
       },
@@ -208,7 +208,7 @@ export const icons: IconDefinition[] = [
       {
         files: path.resolve(
           path.dirname(require.resolve("@primer/octicons")),
-          "build/svg/*-24.svg"
+          "build/svg/*-24.svg",
         ),
         formatter: (name) => `Go${name}`.replace("24", ""),
       },
@@ -224,7 +224,7 @@ export const icons: IconDefinition[] = [
       {
         files: path.resolve(
           path.dirname(require.resolve("feather-icons")),
-          "icons/*.svg"
+          "icons/*.svg",
         ),
         formatter: (name) => `Fi${name}`,
       },
@@ -240,7 +240,7 @@ export const icons: IconDefinition[] = [
       {
         files: path.resolve(
           path.dirname(require.resolve("lucide-static")),
-          "../icons/*.svg"
+          "../icons/*.svg",
         ),
         formatter: (name) => `Lu${name}`,
       },
@@ -256,7 +256,7 @@ export const icons: IconDefinition[] = [
       {
         files: path.resolve(
           __dirname,
-          "../../icons/game-icons-inverted/all-icons/*.svg"
+          "../../icons/game-icons-inverted/all-icons/*.svg",
         ),
         formatter: (name) => `Gi${name}`,
       },
@@ -322,21 +322,21 @@ export const icons: IconDefinition[] = [
       {
         files: path.resolve(
           __dirname,
-          "../../icons/ant-design-icons/packages/icons-svg/svg/filled/*.svg"
+          "../../icons/ant-design-icons/packages/icons-svg/svg/filled/*.svg",
         ),
         formatter: (name) => `AiFill${name}`,
       },
       {
         files: path.resolve(
           __dirname,
-          "../../icons/ant-design-icons/packages/icons-svg/svg/outlined/*.svg"
+          "../../icons/ant-design-icons/packages/icons-svg/svg/outlined/*.svg",
         ),
         formatter: (name) => `AiOutline${name}`,
       },
       {
         files: path.resolve(
           __dirname,
-          "../../icons/ant-design-icons/packages/icons-svg/svg/twotone/*.svg"
+          "../../icons/ant-design-icons/packages/icons-svg/svg/twotone/*.svg",
         ),
         formatter: (name) => `AiTwotone${name}`,
       },
@@ -360,21 +360,21 @@ export const icons: IconDefinition[] = [
       {
         files: path.resolve(
           __dirname,
-          "../../icons/bootstrap/icons/*!(-reverse)-fill.svg"
+          "../../icons/bootstrap/icons/*!(-reverse)-fill.svg",
         ),
         formatter: (name) => `BsFill${name}`,
       },
       {
         files: path.resolve(
           __dirname,
-          "../../icons/bootstrap/icons/*-reverse!(-fill).svg"
+          "../../icons/bootstrap/icons/*-reverse!(-fill).svg",
         ),
         formatter: (name) => `BsReverse${name}`,
       },
       {
         files: path.resolve(
           __dirname,
-          "../../icons/bootstrap/icons/*!(-fill|-reverse|reverse-).svg"
+          "../../icons/bootstrap/icons/*!(-fill|-reverse|reverse-).svg",
         ),
         formatter: (name) => `Bs${name}`,
       },
@@ -419,7 +419,7 @@ export const icons: IconDefinition[] = [
       {
         files: path.resolve(
           __dirname,
-          "../../icons/flat-color-icons/svg/*.svg"
+          "../../icons/flat-color-icons/svg/*.svg",
         ),
         formatter: (name) => `Fc${name}`,
         multiColor: true,
@@ -444,7 +444,7 @@ export const icons: IconDefinition[] = [
       {
         files: path.resolve(
           __dirname,
-          "../../icons/grommet-icons/public/img/*.svg"
+          "../../icons/grommet-icons/public/img/*.svg",
         ),
         formatter: (name) => `Gr${name}`,
       },
@@ -468,14 +468,14 @@ export const icons: IconDefinition[] = [
       {
         files: path.resolve(
           __dirname,
-          "../../icons/heroicons/optimized/solid/*.svg"
+          "../../icons/heroicons/optimized/solid/*.svg",
         ),
         formatter: (name) => `Hi${name}`,
       },
       {
         files: path.resolve(
           __dirname,
-          "../../icons/heroicons/optimized/outline/*.svg"
+          "../../icons/heroicons/optimized/outline/*.svg",
         ),
         formatter: (name) => `HiOutline${name}`,
       },
@@ -499,21 +499,21 @@ export const icons: IconDefinition[] = [
       {
         files: path.resolve(
           __dirname,
-          "../../icons/heroicons-2/optimized/24/solid/*.svg"
+          "../../icons/heroicons-2/optimized/24/solid/*.svg",
         ),
         formatter: (name) => `Hi${name}`,
       },
       {
         files: path.resolve(
           __dirname,
-          "../../icons/heroicons-2/optimized/24/outline/*.svg"
+          "../../icons/heroicons-2/optimized/24/outline/*.svg",
         ),
         formatter: (name) => `HiOutline${name}`,
       },
       {
         files: path.resolve(
           __dirname,
-          "../../icons/heroicons-2/optimized/20/solid/*.svg"
+          "../../icons/heroicons-2/optimized/20/solid/*.svg",
         ),
         formatter: (name) => `HiMini${name}`,
       },
@@ -558,7 +558,7 @@ export const icons: IconDefinition[] = [
       {
         files: path.resolve(
           __dirname,
-          "../../icons/simple-line-icons/src/svgs/*.svg"
+          "../../icons/simple-line-icons/src/svgs/*.svg",
         ),
         formatter: (name) => `Sl${name}`,
       },
@@ -604,7 +604,7 @@ export const icons: IconDefinition[] = [
       {
         files: path.resolve(
           __dirname,
-          "../../icons/boxicons/svg/regular/*.svg"
+          "../../icons/boxicons/svg/regular/*.svg",
         ),
         formatter: (name) => `Bi${name.replace("Bx", "")}`,
       },
@@ -657,7 +657,7 @@ export const icons: IconDefinition[] = [
       {
         files: path.resolve(
           __dirname,
-          "../../icons/vscode-icons/src/icons/*.svg"
+          "../../icons/vscode-icons/src/icons/*.svg",
         ),
         formatter: (name) => `Vsc${name}`,
       },
@@ -724,7 +724,7 @@ export const icons: IconDefinition[] = [
       {
         files: path.resolve(
           __dirname,
-          "../../icons/radix-icons/packages/radix-icons/icons/*.svg"
+          "../../icons/radix-icons/packages/radix-icons/icons/*.svg",
         ),
         formatter: (name) => `Rx${camelcase(name, { pascalCase: true })}`,
       },
@@ -748,7 +748,7 @@ export const icons: IconDefinition[] = [
       {
         files: path.resolve(
           __dirname,
-          "../../icons/phosphor-icons/assets/*/*.svg"
+          "../../icons/phosphor-icons/assets/*/*.svg",
         ),
         formatter: (name) => `Pi${name}`,
       },

--- a/packages/ts-test/public/index.html
+++ b/packages/ts-test/public/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />


### PR DESCRIPTION

To prevent misinformation from being provided, I deleted the icon set version information from the README.md. 
Because the icon set version information is not updated well and the icon version information can be checked in packages/react-icons/VERSIONS.

I improved the issue I mentioned in https://github.com/react-icons/react-icons/issues/832

@kamijin-fanta @gorangajic Could you please review this?

