### PR TITLE
Add Health Icons

### DIFF
--- a/packages/react-icons/VERSIONS
+++ b/packages/react-icons/VERSIONS
@@ -9,7 +9,7 @@
 | [Typicons](http://s-ings.com/typicons/) | [CC BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/) | 2.1.2 | 336 |
 | [Github Octicons icons](https://octicons.github.com/) | [MIT](https://github.com/primer/octicons/blob/master/LICENSE) | 18.3.0 | 264 |
 | [Feather](https://feathericons.com/) | [MIT](https://github.com/feathericons/feather/blob/master/LICENSE) | 4.29.1 | 287 |
-| [Lucide](https://lucide.dev/) | [ISC](https://github.com/lucide-icons/lucide/blob/main/LICENSE) | v4.11.0-15-g7493227d | 1215 |
+| [Lucide](https://lucide.dev/) | [ISC](https://github.com/lucide-icons/lucide/blob/main/LICENSE) | 399b45c3c052cd2666eb6432e1872992a4db5589 | 1215 |
 | [Game Icons](https://game-icons.net/) | [CC BY 3.0](https://creativecommons.org/licenses/by/3.0/) | 12920d6565588f0512542a3cb0cdfd36a497f910 | 4040 |
 | [Weather Icons](https://erikflowers.github.io/weather-icons/) | [SIL OFL 1.1](http://scripts.sil.org/OFL) | 2.0.12 | 219 |
 | [Devicons](https://vorillaz.github.io/devicons/) | [MIT](https://opensource.org/licenses/MIT) | 1.8.0 | 192 |
@@ -31,3 +31,4 @@
 | [Radix Icons](https://icons.radix-ui.com) | [MIT](https://github.com/radix-ui/icons/blob/master/LICENSE) | @radix-ui/react-icons@1.3.0-1-g94b3fcf | 318 |
 | [Phosphor Icons](https://github.com/phosphor-icons/core) | [MIT](https://github.com/phosphor-icons/core/blob/main/LICENSE) | 2.0.2 | 7488 |
 | [Icons8 Line Awesome](https://icons8.com/line-awesome) | [MIT](https://github.com/icons8/line-awesome/blob/master/LICENSE.md) | 1.3.1 | 1544 |
+| [Health Icons](https://healthicons.org/) | [MIT](https://github.com/resolvetosavelives/healthicons/blob/main/LICENSE) | 0.1.0 | 1797 |

--- a/packages/react-icons/src/icons/index.ts
+++ b/packages/react-icons/src/icons/index.ts
@@ -787,4 +787,42 @@ export const icons: IconDefinition[] = [
       hash: "78a101217707c9b1c4dcf2a821be75684e36307f",
     },
   },
+  {
+    id: "hti",
+    name: "Health Icons",
+    contents: [
+      {
+        files: path.resolve(
+          __dirname,
+          "../../icons/healthicons/public/icons/svg/filled/*/*.svg",
+        ),
+        formatter: (name) => `HtiFilled${camelcase(name, { pascalCase: true })}`.replace("!", "ExclamationMark"),
+      },
+      {
+        files: path.resolve(
+          __dirname,
+          "../../icons/healthicons/public/icons/svg/negative/*/*.svg",
+        ),
+        formatter: (name) => `HtiNegative${camelcase(name, { pascalCase: true })}`.replace("!", "ExclamationMark"),
+      },
+      {
+        files: path.resolve(
+          __dirname,
+          "../../icons/healthicons/public/icons/svg/outline/*/*.svg",
+        ),
+        formatter: (name) => `HtiOutline${camelcase(name, { pascalCase: true })}`.replace("!", "ExclamationMark"),
+      },
+    ],
+    projectUrl: "https://healthicons.org/",
+    license: "MIT",
+    licenseUrl: "https://github.com/resolvetosavelives/healthicons/blob/main/LICENSE",
+    source: {
+      type: "git",
+      localName: "healthicons",
+      remoteDir: "public/icons/svg/",
+      url: "https://github.com/resolvetosavelives/healthicons.git",
+      branch: "main",
+      hash: "57df21dda664a633479e4fc2fe50227dba963734",
+    },
+  },
 ];


### PR DESCRIPTION
This pull request adds Health Icons.

repo source : https://github.com/resolvetosavelives/healthicons
related issue : #677  

preview : 
![image](https://github.com/react-icons/react-icons/assets/103256915/5b0429d3-1585-4a5c-88bd-3be6900bda14)

I think this icon-set will be useful.
Please let me know if any changes are needed.