### PR TITLE
Fix Grammatical Error

### DIFF
--- a/packages/preview-astro/src/components/icondetailmodal.tsx
+++ b/packages/preview-astro/src/components/icondetailmodal.tsx
@@ -97,7 +97,7 @@ export function IconDetailModal(
             </button>
           ))}
         </div>
-        <h2>Codes</h2>
+        <h2>Code</h2>
         <pre>
           <code>{importCode}</code>
         </pre>


### PR DESCRIPTION
Code" in the sense of "computer code" is a mass noun, so this removes the extra S.