### PR TITLE
feat: update lucide icons to 0.394.0

### DIFF
--- a/packages/react-icons/VERSIONS
+++ b/packages/react-icons/VERSIONS
@@ -9,7 +9,7 @@
 | [Typicons](http://s-ings.com/typicons/) | [CC BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/) | 2.1.2 | 336 |
 | [Github Octicons icons](https://octicons.github.com/) | [MIT](https://github.com/primer/octicons/blob/master/LICENSE) | 18.3.0 | 264 |
 | [Feather](https://feathericons.com/) | [MIT](https://github.com/feathericons/feather/blob/master/LICENSE) | 4.29.1 | 287 |
-| [Lucide](https://lucide.dev/) | [ISC](https://github.com/lucide-icons/lucide/blob/main/LICENSE) | v5.1.0-6-g438f572e | 1215 |
+| [Lucide](https://lucide.dev/) | [ISC](https://github.com/lucide-icons/lucide/blob/main/LICENSE) | 0.394.0 | 1468 |
 | [Game Icons](https://game-icons.net/) | [CC BY 3.0](https://creativecommons.org/licenses/by/3.0/) | 12920d6565588f0512542a3cb0cdfd36a497f910 | 4040 |
 | [Weather Icons](https://erikflowers.github.io/weather-icons/) | [SIL OFL 1.1](http://scripts.sil.org/OFL) | 2.0.12 | 219 |
 | [Devicons](https://vorillaz.github.io/devicons/) | [MIT](https://opensource.org/licenses/MIT) | 1.8.0 | 192 |

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -43,7 +43,7 @@
     "glob-promise": "^6.0.5",
     "ionicons": "^4.6.3",
     "ionicons-5": "npm:ionicons@5",
-    "lucide-static": "^0.263.0",
+    "lucide-static": "^0.394.0",
     "p-queue": "^8.0.1",
     "svgo": "^3.0.3",
     "typescript": "^5.4.5"

--- a/packages/react-icons/src/icons/index.ts
+++ b/packages/react-icons/src/icons/index.ts
@@ -240,7 +240,7 @@ export const icons: IconDefinition[] = [
       {
         files: path.resolve(
           path.dirname(require.resolve("lucide-static")),
-          "../icons/*.svg",
+          "../../icons/*.svg",
         ),
         formatter: (name) => `Lu${name}`,
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -14878,10 +14878,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lucide-static@npm:^0.263.0":
-  version: 0.263.0
-  resolution: "lucide-static@npm:0.263.0"
-  checksum: 62b07a917fac9ce37c492c2da16e84e4a6417034f7e114519194b3fe6d25a1e065c26e12bdf6ee1ce8a2dd0cc54adf6c3501902f32e95870d43b83216080ccbf
+"lucide-static@npm:^0.394.0":
+  version: 0.394.0
+  resolution: "lucide-static@npm:0.394.0"
+  checksum: 924616da598bdffa3ccece37ec7129704f16246a3a7e248a76a91f55c3a7fc6fad207b149b2e9e319ec92d649b47d92e14fe16b07e8a7280d71940ec0508d9f6
   languageName: node
   linkType: hard
 
@@ -18636,7 +18636,7 @@ __metadata:
     glob-promise: ^6.0.5
     ionicons: ^4.6.3
     ionicons-5: "npm:ionicons@5"
-    lucide-static: ^0.263.0
+    lucide-static: ^0.394.0
     p-queue: ^8.0.1
     svgo: ^3.0.3
     typescript: ^5.4.5


### PR DESCRIPTION
This PR bumps the version of Lucide icons from 0.263.0 -> 0.394.0 , as there have been a lot of new icons added. I don't know where the old version in the `VERSIONS` file for Lucide came from, `v5.1.0-6-g438f572e` doesn't seem to have ever been a version of Lucide unless I am missing something.

Here's the deployed preview of my fork on GH pages if it helps for reviewing this PR:
https://dgcole.github.io/react-icons/