### PR TITLE
Added autoFocus to the searchBar at landing page

### DIFF
--- a/packages/preview-astro/src/components/searchinput.tsx
+++ b/packages/preview-astro/src/components/searchinput.tsx
@@ -26,6 +26,7 @@ export function SearchInput() {
       type="text"
       aria-label="search"
       className="px2 py1"
+      autoFocus={true}
       placeholder="🔍 Search Icons"
       autoComplete="off"
       autoCorrect="off"


### PR DESCRIPTION
I solved the issue I mentioned in #963 
@kamijin-fanta @gorangajic Could you please review this?
Before my Fix :
The search bar on the landing page is not auto-focused. I found it frustrating several times, This is a minor ux issue but not negligible.
After my Fix :
Now it is auto-focused by default. Now visitors just have to use their keyboard to start browsing icons.