### PR TITLE
Add material rounded icons

### DIFF
--- a/packages/react-icons/src/icons/index.ts
+++ b/packages/react-icons/src/icons/index.ts
@@ -166,6 +166,18 @@ export const icons: IconDefinition[] = [
           )}`,
         processWithSVGO: true,
       },
+      {
+        files: path.resolve(
+          __dirname,
+          "../../icons/material-design-icons/src/*/*/materialiconsround/24px.svg",
+        ),
+        formatter: (name, file) =>
+          `MdRound${camelcase(
+            file.replace(/^.*\/([^/]+)\/materialicons[^/]*\/24px.svg$/i, "$1"),
+            { pascalCase: true },
+          )}`,
+        processWithSVGO: true,
+      },
     ],
     projectUrl: "http://google.github.io/material-design-icons/",
     license: "Apache License Version 2.0",


### PR DESCRIPTION
Can we add Material Rounded icons to the build?

Thanks!

Working in Preview:

<img width="1554" alt="image" src="https://github.com/user-attachments/assets/1e4c6777-009d-40d5-b15f-2fce5a938a48">
