### PR TITLE
#963 fix autofocus search by default

### DIFF
--- a/packages/preview-astro/src/components/searchinput.tsx
+++ b/packages/preview-astro/src/components/searchinput.tsx
@@ -27,6 +27,7 @@ export function SearchInput() {
       aria-label="search"
       className="px2 py1"
       placeholder="🔍 Search Icons"
+      autoFocus
       autoComplete="off"
       autoCorrect="off"
       autoCapitalize="off"


### PR DESCRIPTION
"I've implemented a fix for the issue described in https://github.com/react-icons/react-icons/issues/963. @kamijin-fanta @gorangajic, could you take a look?

Before the Fix:
The search bar on the landing page didn't auto-focus, which could be a slight inconvenience for users.

After the Fix:
The search bar now automatically gains focus when the page loads, making it easier for visitors to start searching for icons using their keyboard."

