### PR TITLE
min search length changed to 2

### DIFF
--- a/packages/preview-astro/src/components/search/index.tsx
+++ b/packages/preview-astro/src/components/search/index.tsx
@@ -17,7 +17,7 @@ export function SearchPageComponent() {
     setIsFirstRender(false);
   }, []);
 
-  if (!isFirstRender && query?.length > 2) {
+  if (!isFirstRender && query?.length > 1) {
     const hightlightPattern = new RegExp(
       `(${query
         .replace(/[\\^$.*+?()[\]{}|]/g, "\\$&")
@@ -54,5 +54,5 @@ export function SearchPageComponent() {
       </>
     );
   }
-  return <h2>Please enter at least 3 characters to search...</h2>;
+  return <h2>Please enter at least 2 characters to search...</h2>;
 }


### PR DESCRIPTION
fix #468 

"I've addressed the request to decrease the minimum search query length to 2. @kamijin-fanta @gorangajic, could you please review the change?

Previously, the search functionality required a minimum of 3 characters, which limited users' ability to search for shorter terms. With the update, the minimum query length is now 2 characters, allowing for more flexible and efficient searches."