### PR TITLE
support moduleResolution: bundler in tsconfig

### DIFF
--- a/packages/react-icons/scripts/task_common.ts
+++ b/packages/react-icons/scripts/task_common.ts
@@ -73,7 +73,7 @@ export async function writeEntryPoints({ DIST, LIB, rootDir }: TaskContext) {
   );
   await fs.appendFile(
     path.resolve(DIST, "index.d.ts"),
-    generateEntryMjs("index.d.ts"),
+    generateEntryMjs("index"),
     "utf8",
   );
 }


### PR DESCRIPTION
fix #948 

modify the type definitions to enhance compatibility with `tsc` and fix the error that occurs when `compilerOptions.moduleResolution` in `tsconfig.json` is set to `"bundler"`.