### PR TITLE
feat: added copy to clipboard button to code blocks #901

### DIFF
--- a/packages/preview-astro/src/components/copyTextWithIcon.tsx
+++ b/packages/preview-astro/src/components/copyTextWithIcon.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import toast from "cogo-toast";
+import copy from "copy-to-clipboard";
+import { FaRegClipboard } from "react-icons/fa6";
+
+export default function CopyTextWithIcon(props: {
+    text: string;
+}) {
+    const handleCopy = () => {
+        copy(props.text);
+
+        toast.success(`Copied '${props.text}' to clipboard`, {
+            position: "bottom-center",
+        });
+    };
+
+    return (
+      <pre className="pre-clipboard">
+        <FaRegClipboard 
+            className="clipboard-icon" 
+            onClick={handleCopy}
+        />
+  
+        <code> 
+            {props.text} 
+        </code>
+      </pre>
+    );
+};

--- a/packages/preview-astro/src/components/icondetailmodal.tsx
+++ b/packages/preview-astro/src/components/icondetailmodal.tsx
@@ -58,6 +58,8 @@ export interface IconDetailModalProps {
   component?: React.ComponentType | undefined;
   onClose?(): void;
 }
+
+
 export function IconDetailModal(
   props: IconDetailModalProps,
 ): React.ReactElement {
@@ -99,12 +101,26 @@ export function IconDetailModal(
           ))}
         </div>
         <h2>Code</h2>
-        <pre>
-          <code>{importCode}</code>
-        </pre>
-        <pre>
-          <code>{useCode}</code>
-        </pre>
+        {[
+          importCode,
+          useCode
+        ].map((text, i) => (
+          <pre
+            key={i}
+            className="pre-clipboard"
+          >
+            <FaRegClipboard className="clipboard-icon" onClick={()=> {
+              copy(text ?? "");
+
+              toast.success(`Copied '${text ?? ""}' to clipboard`, {
+                position: "bottom-center",
+              })
+            }}/>
+
+            <code> {text} </code>
+          </pre>
+        ))}
+
         <ul className="copy">
           {[
             props.iconSet,

--- a/packages/preview-astro/src/pages/icons/[name].astro
+++ b/packages/preview-astro/src/pages/icons/[name].astro
@@ -4,6 +4,7 @@ import Container from "../../components/container.astro";
 import Layout from "../../layouts/Layout.astro";
 import { IconSetViewer } from "../../components/iconset-viewer.tsx";
 import { IconsManifest } from "react-icons";
+import CopyTextWithIcon from "../../components/copyTextWithIcon.tsx";
 
 export async function getStaticPaths() {
   return Promise.all(
@@ -71,11 +72,7 @@ const { manifest } = Astro.props;
     </dl>
 
     <h2>Import</h2>
-    <Code
-      lang="jsx"
-      code={`import { IconName } from "react-icons/${manifest.id}";`}
-    />
-
+    <CopyTextWithIcon client:load text={`import ${`{ IconName }`} from "react-icons/${manifest.id}"`} />
     <IconSetViewer client:load iconSet={manifest.id} />
   </Container>
 </Layout>

--- a/packages/preview-astro/src/styles/_components.scss
+++ b/packages/preview-astro/src/styles/_components.scss
@@ -368,6 +368,22 @@ html:has(.modal-root.active) {
   }
 }
 
+.pre-clipboard {
+  overflow: auto;
+  background-color: #24292e;
+  color: #e1e4e8;
+  padding: 10px;
+  border-radius: 5px;
+  margin-top: 10px;
+
+  .clipboard-icon {
+    width: 16px;
+    height: 16px;
+    margin-right: 4px;
+    cursor: pointer;
+  }
+}
+
 .icon-detail-modal-content {
   .icon {
     text-align: center;
@@ -381,6 +397,7 @@ html:has(.modal-root.active) {
     padding: 10px;
     border-radius: 5px;
   }
+
   ul.copy {
     list-style: none;
     padding: 0;


### PR DESCRIPTION
Added a "Copy to Clipboard" button to code blocks, streamlining the process of copying code directly from documentation or code samples. This enhancement improves user experience by making it easier and faster to copy code, especially in tutorials and guides.

This implementation was done for ticket #901 