### PR TITLE
feat: allow tree shaking in react-icons

### DIFF
--- a/packages/_react-icons_all-files/package.json
+++ b/packages/_react-icons_all-files/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-icons/all-files",
-  "version": "5.2.1",
+  "version": "5.3.0",
   "description": "SVG React icons of popular icon packs using ES6 imports",
   "author": "Goran Gajic",
   "contributors": [

--- a/packages/_react-icons_all/package.json
+++ b/packages/_react-icons_all/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-icons",
-  "version": "5.2.1",
+  "version": "5.3.0",
   "description": "SVG React icons of popular icon packs using ES6 imports",
   "author": "Goran Gajic",
   "contributors": [
@@ -41,11 +41,21 @@
       "import": "./ci/index.mjs",
       "default": "./ci/index.mjs"
     },
+    "./ci/*": {
+      "types": "./ci/*.d.ts",
+      "import": "./ci/*.mjs",
+      "require": "./ci/*.js"
+    },
     "./fa": {
       "types": "./fa/index.d.ts",
       "require": "./fa/index.js",
       "import": "./fa/index.mjs",
       "default": "./fa/index.mjs"
+    },
+    "./fa/*": {
+      "types": "./fa/*.d.ts",
+      "import": "./fa/*.mjs",
+      "require": "./fa/*.js"
     },
     "./fa6": {
       "types": "./fa6/index.d.ts",
@@ -53,11 +63,21 @@
       "import": "./fa6/index.mjs",
       "default": "./fa6/index.mjs"
     },
+    "./fa6/*": {
+      "types": "./fa6/*.d.ts",
+      "import": "./fa6/*.mjs",
+      "require": "./fa6/*.js"
+    },
     "./io": {
       "types": "./io/index.d.ts",
       "require": "./io/index.js",
       "import": "./io/index.mjs",
       "default": "./io/index.mjs"
+    },
+    "./io/*": {
+      "types": "./io/*.d.ts",
+      "import": "./io/*.mjs",
+      "require": "./io/*.js"
     },
     "./io5": {
       "types": "./io5/index.d.ts",
@@ -65,11 +85,21 @@
       "import": "./io5/index.mjs",
       "default": "./io5/index.mjs"
     },
+    "./io5/*": {
+      "types": "./io5/*.d.ts",
+      "import": "./io5/*.mjs",
+      "require": "./io5/*.js"
+    },
     "./md": {
       "types": "./md/index.d.ts",
       "require": "./md/index.js",
       "import": "./md/index.mjs",
       "default": "./md/index.mjs"
+    },
+    "./md/*": {
+      "types": "./md/*.d.ts",
+      "import": "./md/*.mjs",
+      "require": "./md/*.js"
     },
     "./ti": {
       "types": "./ti/index.d.ts",
@@ -77,11 +107,21 @@
       "import": "./ti/index.mjs",
       "default": "./ti/index.mjs"
     },
+    "./ti/*": {
+      "types": "./ti/*.d.ts",
+      "import": "./ti/*.mjs",
+      "require": "./ti/*.js"
+    },
     "./go": {
       "types": "./go/index.d.ts",
       "require": "./go/index.js",
       "import": "./go/index.mjs",
       "default": "./go/index.mjs"
+    },
+    "./go/*": {
+      "types": "./go/*.d.ts",
+      "import": "./go/*.mjs",
+      "require": "./go/*.js"
     },
     "./fi": {
       "types": "./fi/index.d.ts",
@@ -89,11 +129,21 @@
       "import": "./fi/index.mjs",
       "default": "./fi/index.mjs"
     },
+    "./fi/*": {
+      "types": "./fi/*.d.ts",
+      "import": "./fi/*.mjs",
+      "require": "./fi/*.js"
+    },
     "./lu": {
       "types": "./lu/index.d.ts",
       "require": "./lu/index.js",
       "import": "./lu/index.mjs",
       "default": "./lu/index.mjs"
+    },
+    "./lu/*": {
+      "types": "./lu/*.d.ts",
+      "import": "./lu/*.mjs",
+      "require": "./lu/*.js"
     },
     "./gi": {
       "types": "./gi/index.d.ts",
@@ -101,11 +151,21 @@
       "import": "./gi/index.mjs",
       "default": "./gi/index.mjs"
     },
+    "./gi/*": {
+      "types": "./gi/*.d.ts",
+      "import": "./gi/*.mjs",
+      "require": "./gi/*.js"
+    },
     "./wi": {
       "types": "./wi/index.d.ts",
       "require": "./wi/index.js",
       "import": "./wi/index.mjs",
       "default": "./wi/index.mjs"
+    },
+    "./wi/*": {
+      "types": "./wi/*.d.ts",
+      "import": "./wi/*.mjs",
+      "require": "./wi/*.js"
     },
     "./di": {
       "types": "./di/index.d.ts",
@@ -113,11 +173,21 @@
       "import": "./di/index.mjs",
       "default": "./di/index.mjs"
     },
+    "./di/*": {
+      "types": "./di/*.d.ts",
+      "import": "./di/*.mjs",
+      "require": "./di/*.js"
+    },
     "./ai": {
       "types": "./ai/index.d.ts",
       "require": "./ai/index.js",
       "import": "./ai/index.mjs",
       "default": "./ai/index.mjs"
+    },
+    "./ai/*": {
+      "types": "./ai/*.d.ts",
+      "import": "./ai/*.mjs",
+      "require": "./ai/*.js"
     },
     "./bs": {
       "types": "./bs/index.d.ts",
@@ -125,11 +195,21 @@
       "import": "./bs/index.mjs",
       "default": "./bs/index.mjs"
     },
+    "./bs/*": {
+      "types": "./bs/*.d.ts",
+      "import": "./bs/*.mjs",
+      "require": "./bs/*.js"
+    },
     "./ri": {
       "types": "./ri/index.d.ts",
       "require": "./ri/index.js",
       "import": "./ri/index.mjs",
       "default": "./ri/index.mjs"
+    },
+    "./ri/*": {
+      "types": "./ri/*.d.ts",
+      "import": "./ri/*.mjs",
+      "require": "./ri/*.js"
     },
     "./fc": {
       "types": "./fc/index.d.ts",
@@ -137,11 +217,21 @@
       "import": "./fc/index.mjs",
       "default": "./fc/index.mjs"
     },
+    "./fc/*": {
+      "types": "./fc/*.d.ts",
+      "import": "./fc/*.mjs",
+      "require": "./fc/*.js"
+    },
     "./gr": {
       "types": "./gr/index.d.ts",
       "require": "./gr/index.js",
       "import": "./gr/index.mjs",
       "default": "./gr/index.mjs"
+    },
+    "./gr/*": {
+      "types": "./gr/*.d.ts",
+      "import": "./gr/*.mjs",
+      "require": "./gr/*.js"
     },
     "./hi": {
       "types": "./hi/index.d.ts",
@@ -149,11 +239,21 @@
       "import": "./hi/index.mjs",
       "default": "./hi/index.mjs"
     },
+    "./hi/*": {
+      "types": "./hi/*.d.ts",
+      "import": "./hi/*.mjs",
+      "require": "./hi/*.js"
+    },
     "./hi2": {
       "types": "./hi2/index.d.ts",
       "require": "./hi2/index.js",
       "import": "./hi2/index.mjs",
       "default": "./hi2/index.mjs"
+    },
+    "./hi2/*": {
+      "types": "./hi2/*.d.ts",
+      "import": "./hi2/*.mjs",
+      "require": "./hi2/*.js"
     },
     "./si": {
       "types": "./si/index.d.ts",
@@ -161,11 +261,21 @@
       "import": "./si/index.mjs",
       "default": "./si/index.mjs"
     },
+    "./si/*": {
+      "types": "./si/*.d.ts",
+      "import": "./si/*.mjs",
+      "require": "./si/*.js"
+    },
     "./sl": {
       "types": "./sl/index.d.ts",
       "require": "./sl/index.js",
       "import": "./sl/index.mjs",
       "default": "./sl/index.mjs"
+    },
+    "./sl/*": {
+      "types": "./sl/*.d.ts",
+      "import": "./sl/*.mjs",
+      "require": "./sl/*.js"
     },
     "./im": {
       "types": "./im/index.d.ts",
@@ -173,11 +283,21 @@
       "import": "./im/index.mjs",
       "default": "./im/index.mjs"
     },
+    "./im/*": {
+      "types": "./im/*.d.ts",
+      "import": "./im/*.mjs",
+      "require": "./im/*.js"
+    },
     "./bi": {
       "types": "./bi/index.d.ts",
       "require": "./bi/index.js",
       "import": "./bi/index.mjs",
       "default": "./bi/index.mjs"
+    },
+    "./bi/*": {
+      "types": "./bi/*.d.ts",
+      "import": "./bi/*.mjs",
+      "require": "./bi/*.js"
     },
     "./cg": {
       "types": "./cg/index.d.ts",
@@ -185,11 +305,21 @@
       "import": "./cg/index.mjs",
       "default": "./cg/index.mjs"
     },
+    "./cg/*": {
+      "types": "./cg/*.d.ts",
+      "import": "./cg/*.mjs",
+      "require": "./cg/*.js"
+    },
     "./vsc": {
       "types": "./vsc/index.d.ts",
       "require": "./vsc/index.js",
       "import": "./vsc/index.mjs",
       "default": "./vsc/index.mjs"
+    },
+    "./vsc/*": {
+      "types": "./vsc/*.d.ts",
+      "import": "./vsc/*.mjs",
+      "require": "./vsc/*.js"
     },
     "./tb": {
       "types": "./tb/index.d.ts",
@@ -197,11 +327,21 @@
       "import": "./tb/index.mjs",
       "default": "./tb/index.mjs"
     },
+    "./tb/*": {
+      "types": "./tb/*.d.ts",
+      "import": "./tb/*.mjs",
+      "require": "./tb/*.js"
+    },
     "./tfi": {
       "types": "./tfi/index.d.ts",
       "require": "./tfi/index.js",
       "import": "./tfi/index.mjs",
       "default": "./tfi/index.mjs"
+    },
+    "./tfi/*": {
+      "types": "./tfi/*.d.ts",
+      "import": "./tfi/*.mjs",
+      "require": "./tfi/*.js"
     },
     "./rx": {
       "types": "./rx/index.d.ts",
@@ -209,17 +349,32 @@
       "import": "./rx/index.mjs",
       "default": "./rx/index.mjs"
     },
+    "./rx/*": {
+      "types": "./rx/*.d.ts",
+      "import": "./rx/*.mjs",
+      "require": "./rx/*.js"
+    },
     "./pi": {
       "types": "./pi/index.d.ts",
       "require": "./pi/index.js",
       "import": "./pi/index.mjs",
       "default": "./pi/index.mjs"
     },
+    "./pi/*": {
+      "types": "./pi/*.d.ts",
+      "import": "./pi/*.mjs",
+      "require": "./pi/*.js"
+    },
     "./lia": {
       "types": "./lia/index.d.ts",
       "require": "./lia/index.js",
       "import": "./lia/index.mjs",
       "default": "./lia/index.mjs"
+    },
+    "./lia/*": {
+      "types": "./lia/*.d.ts",
+      "import": "./lia/*.mjs",
+      "require": "./lia/*.js"
     }
   }
 }

--- a/packages/preview-astro/src/components/icondetailmodal.tsx
+++ b/packages/preview-astro/src/components/icondetailmodal.tsx
@@ -153,23 +153,22 @@ const useModalAnimation = ({ onClose, isOpen }: useModalAnimationProps) => {
     handleInitOpenAnimation();
   }, [isOpen]);
 
-
   useEffect(() => {
     const modalElement = modalRef.current;
-  
+
     const handleTransitionEnd = () => {
       if (!animationIsOpen) {
         onClose?.();
       }
     };
-  
+
     if (modalElement) {
-      modalElement.addEventListener('transitionend', handleTransitionEnd);
+      modalElement.addEventListener("transitionend", handleTransitionEnd);
     }
 
     return () => {
       if (modalElement) {
-        modalElement.removeEventListener('transitionend', handleTransitionEnd);
+        modalElement.removeEventListener("transitionend", handleTransitionEnd);
       }
     };
   }, [animationIsOpen, onClose]);
@@ -181,7 +180,7 @@ const useModalAnimation = ({ onClose, isOpen }: useModalAnimationProps) => {
   return {
     animationIsOpen,
     handleCloseModal,
-    modalRef
+    modalRef,
   };
 };
 
@@ -215,7 +214,10 @@ function Modal({
         className={`overlay ${animationIsOpen ? "" : "appearing"}`}
         onClick={() => handleCloseModal()}
       ></div>
-      <div className={`modal-body ${animationIsOpen ? "open" : "close"}`} ref={modalRef}>
+      <div
+        className={`modal-body ${animationIsOpen ? "open" : "close"}`}
+        ref={modalRef}
+      >
         <div className="header">
           <h3 className="title">{title}</h3>
           <button

--- a/packages/react-icons/VERSIONS
+++ b/packages/react-icons/VERSIONS
@@ -9,7 +9,7 @@
 | [Typicons](http://s-ings.com/typicons/) | [CC BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/) | 2.1.2 | 336 |
 | [Github Octicons icons](https://octicons.github.com/) | [MIT](https://github.com/primer/octicons/blob/master/LICENSE) | 18.3.0 | 264 |
 | [Feather](https://feathericons.com/) | [MIT](https://github.com/feathericons/feather/blob/master/LICENSE) | 4.29.1 | 287 |
-| [Lucide](https://lucide.dev/) | [ISC](https://github.com/lucide-icons/lucide/blob/main/LICENSE) | v5.2.1-3-g03c80d93 | 1215 |
+| [Lucide](https://lucide.dev/) | [ISC](https://github.com/lucide-icons/lucide/blob/main/LICENSE) | v5.3.0-10-g8648bd93 | 1215 |
 | [Game Icons](https://game-icons.net/) | [CC BY 3.0](https://creativecommons.org/licenses/by/3.0/) | 12920d6565588f0512542a3cb0cdfd36a497f910 | 4040 |
 | [Weather Icons](https://erikflowers.github.io/weather-icons/) | [SIL OFL 1.1](http://scripts.sil.org/OFL) | 2.0.12 | 219 |
 | [Devicons](https://vorillaz.github.io/devicons/) | [MIT](https://opensource.org/licenses/MIT) | 1.8.0 | 192 |

--- a/packages/react-icons/scripts/build.ts
+++ b/packages/react-icons/scripts/build.ts
@@ -34,7 +34,7 @@ async function main() {
       await taskCommon.writePackageJson(
         {
           name: "react-icons",
-          exports: buildPackageExports({ icons, addLibraryExport: true }),
+          exports: buildPackageExports({ icons, addLibraryExport: true, addSubAllExport: true }),
         },
         allOpt,
       );
@@ -42,7 +42,10 @@ async function main() {
     });
     await task("@react-icons/all write icons", async () => {
       await Promise.all(
-        icons.map((icon) => taskAll.writeIconModule(icon, allOpt)),
+        icons.map((icon) => {
+          taskAll.writeIconModule(icon, allOpt, true);
+          taskFiles.writeIconModuleFiles(icon, allOpt);
+        }),
       );
     });
 
@@ -66,26 +69,7 @@ async function main() {
     await task("@react-icons/all-files write icons", async () => {
       await Promise.all(
         icons.map(async (icon) => {
-          taskAll.writeIconModule(icon, filesOpt, true);
           taskFiles.writeIconModuleFiles(icon, filesOpt);
-          console.log(icon);
-          const iconPackageOpt = {
-            ...filesOpt,
-            DIST: `${filesOpt.DIST}/${icon.id}`,
-          };
-          // await taskCommon.writeEntryPoints(iconPackageOpt);
-          await taskCommon.writeIconsManifest(iconPackageOpt);
-          await taskCommon.writeLicense(iconPackageOpt);
-          await taskCommon.writePackageJson(
-            {
-              name: `@react-icons/${icon.id}`,
-              exports: buildPackageExports(),
-              main: "./index.js",
-              module: "./index.mjs",
-              types: "./index.d.ts",
-            },
-            iconPackageOpt,
-          );
         }),
       );
     });

--- a/packages/react-icons/scripts/build.ts
+++ b/packages/react-icons/scripts/build.ts
@@ -32,7 +32,10 @@ async function main() {
       await taskCommon.writeIconsManifest(allOpt);
       await taskCommon.writeLicense(allOpt);
       await taskCommon.writePackageJson(
-        { name: "react-icons", exports: buildPackageExports(icons) },
+        {
+          name: "react-icons",
+          exports: buildPackageExports({ icons, addLibraryExport: true }),
+        },
         allOpt,
       );
       await taskCommon.copyReadme(allOpt);
@@ -62,7 +65,28 @@ async function main() {
     });
     await task("@react-icons/all-files write icons", async () => {
       await Promise.all(
-        icons.map((icon) => taskFiles.writeIconModuleFiles(icon, filesOpt)),
+        icons.map(async (icon) => {
+          taskAll.writeIconModule(icon, filesOpt, true);
+          taskFiles.writeIconModuleFiles(icon, filesOpt);
+          console.log(icon);
+          const iconPackageOpt = {
+            ...filesOpt,
+            DIST: `${filesOpt.DIST}/${icon.id}`,
+          };
+          // await taskCommon.writeEntryPoints(iconPackageOpt);
+          await taskCommon.writeIconsManifest(iconPackageOpt);
+          await taskCommon.writeLicense(iconPackageOpt);
+          await taskCommon.writePackageJson(
+            {
+              name: `@react-icons/${icon.id}`,
+              exports: buildPackageExports(),
+              main: "./index.js",
+              module: "./index.mjs",
+              types: "./index.d.ts",
+            },
+            iconPackageOpt,
+          );
+        }),
       );
     });
 

--- a/packages/react-icons/scripts/build.ts
+++ b/packages/react-icons/scripts/build.ts
@@ -34,7 +34,11 @@ async function main() {
       await taskCommon.writePackageJson(
         {
           name: "react-icons",
-          exports: buildPackageExports({ icons, addLibraryExport: true, addSubAllExport: true }),
+          exports: buildPackageExports({
+            icons,
+            addLibraryExport: true,
+            addSubAllExport: true,
+          }),
         },
         allOpt,
       );

--- a/packages/react-icons/scripts/logics.ts
+++ b/packages/react-icons/scripts/logics.ts
@@ -120,7 +120,12 @@ export function buildPackageExports(
     icons?: IconManifestType[];
   } = {},
 ) {
-  const { addLibraryExport, addAllExport, addSubAllExport, icons = [] } = options;
+  const {
+    addLibraryExport,
+    addAllExport,
+    addSubAllExport,
+    icons = [],
+  } = options;
   const exports: Record<
     string,
     {

--- a/packages/react-icons/scripts/logics.ts
+++ b/packages/react-icons/scripts/logics.ts
@@ -112,15 +112,22 @@ export async function rmDirRecursive(dest: string) {
   await fs.rm(dest, { recursive: true, force: true });
 }
 
-export function buildPackageExports(options: { addLibraryExport?: boolean, icons?: IconManifestType[]} = {}) {
-  const { addLibraryExport, icons = [] } = options
+export function buildPackageExports(
+  options: {
+    addLibraryExport?: boolean;
+    addAllExport?: boolean;
+    addSubAllExport?: boolean;
+    icons?: IconManifestType[];
+  } = {},
+) {
+  const { addLibraryExport, addAllExport, addSubAllExport, icons = [] } = options;
   const exports: Record<
     string,
     {
       types: string;
       require: string;
       import: string;
-      default: string;
+      default?: string;
     }
   > = {
     ".": {
@@ -131,12 +138,20 @@ export function buildPackageExports(options: { addLibraryExport?: boolean, icons
     },
   };
 
-  if (addLibraryExport) exports["./lib"] = {
-    types: "./lib/index.d.ts",
-    require: "./lib/index.js",
-    import: "./lib/index.mjs",
-    default: "./lib/index.mjs",
-  };
+  if (addLibraryExport)
+    exports["./lib"] = {
+      types: "./lib/index.d.ts",
+      require: "./lib/index.js",
+      import: "./lib/index.mjs",
+      default: "./lib/index.mjs",
+    };
+
+  if (addAllExport)
+    exports["./*"] = {
+      types: "./*.d.ts",
+      import: "./*.mjs",
+      require: "./*.js",
+    };
 
   icons.forEach((icon) => {
     exports[`./${icon.id}`] = {
@@ -145,6 +160,13 @@ export function buildPackageExports(options: { addLibraryExport?: boolean, icons
       import: `./${icon.id}/index.mjs`,
       default: `./${icon.id}/index.mjs`,
     };
+    if (addSubAllExport) {
+      exports[`./${icon.id}/*`] = {
+        types: `./${icon.id}/*.d.ts`,
+        import: `./${icon.id}/*.mjs`,
+        require: `./${icon.id}/*.js`,
+      };
+    }
   });
 
   return exports;

--- a/packages/react-icons/scripts/logics.ts
+++ b/packages/react-icons/scripts/logics.ts
@@ -112,7 +112,8 @@ export async function rmDirRecursive(dest: string) {
   await fs.rm(dest, { recursive: true, force: true });
 }
 
-export function buildPackageExports(icons: IconManifestType[]) {
+export function buildPackageExports(options: { addLibraryExport?: boolean, icons?: IconManifestType[]} = {}) {
+  const { addLibraryExport, icons = [] } = options
   const exports: Record<
     string,
     {
@@ -128,12 +129,13 @@ export function buildPackageExports(icons: IconManifestType[]) {
       import: "./index.mjs",
       default: "./index.mjs",
     },
-    "./lib": {
-      types: "./lib/index.d.ts",
-      require: "./lib/index.js",
-      import: "./lib/index.mjs",
-      default: "./lib/index.mjs",
-    },
+  };
+
+  if (addLibraryExport) exports["./lib"] = {
+    types: "./lib/index.d.ts",
+    require: "./lib/index.js",
+    import: "./lib/index.mjs",
+    default: "./lib/index.mjs",
   };
 
   icons.forEach((icon) => {

--- a/packages/react-icons/scripts/task_all.ts
+++ b/packages/react-icons/scripts/task_all.ts
@@ -28,14 +28,8 @@ export async function dirInit({ DIST, LIB, rootDir }: TaskContext) {
   for (const icon of icons) {
     await fs.mkdir(path.resolve(DIST, icon.id)).catch(ignore);
 
-    await write(
-      [icon.id, "index.js"],
-      "// THIS FILE IS AUTO GENERATED\n",
-    );
-    await write(
-      [icon.id, "index.mjs"],
-      "// THIS FILE IS AUTO GENERATED\n",
-    );
+    await write([icon.id, "index.js"], "// THIS FILE IS AUTO GENERATED\n");
+    await write([icon.id, "index.mjs"], "// THIS FILE IS AUTO GENERATED\n");
     await write(
       [icon.id, "index.d.ts"],
       "// THIS FILE IS AUTO GENERATED\nimport type { IconType } from '../lib/index'\n",
@@ -61,7 +55,7 @@ export async function writeIconModule(
   icon: IconDefinition,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   { DIST, LIB, rootDir }: TaskContext,
-  reExport: boolean = false
+  reExport: boolean = false,
 ) {
   const exists = new Set(); // for remove duplicate
   for (const content of icon.contents) {

--- a/packages/react-icons/scripts/task_all.ts
+++ b/packages/react-icons/scripts/task_all.ts
@@ -30,11 +30,11 @@ export async function dirInit({ DIST, LIB, rootDir }: TaskContext) {
 
     await write(
       [icon.id, "index.js"],
-      "// THIS FILE IS AUTO GENERATED\nvar GenIcon = require('../lib').GenIcon\n",
+      "// THIS FILE IS AUTO GENERATED\n",
     );
     await write(
       [icon.id, "index.mjs"],
-      "// THIS FILE IS AUTO GENERATED\nimport { GenIcon } from '../lib/index.mjs';\n",
+      "// THIS FILE IS AUTO GENERATED\n",
     );
     await write(
       [icon.id, "index.d.ts"],

--- a/packages/react-icons/scripts/task_all.ts
+++ b/packages/react-icons/scripts/task_all.ts
@@ -61,6 +61,7 @@ export async function writeIconModule(
   icon: IconDefinition,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   { DIST, LIB, rootDir }: TaskContext,
+  reExport: boolean = false
 ) {
   const exists = new Set(); // for remove duplicate
   for (const content of icon.contents) {
@@ -83,19 +84,19 @@ export async function writeIconModule(
       exists.add(name);
 
       // write like: module/fa/index.mjs
-      const modRes = iconRowTemplate(icon, name, iconData, "module");
+      const modRes = iconRowTemplate(icon, name, iconData, "module", reExport);
       await fs.appendFile(
         path.resolve(DIST, icon.id, "index.mjs"),
         modRes,
         "utf8",
       );
-      const comRes = iconRowTemplate(icon, name, iconData, "common");
+      const comRes = iconRowTemplate(icon, name, iconData, "common", reExport);
       await fs.appendFile(
         path.resolve(DIST, icon.id, "index.js"),
         comRes,
         "utf8",
       );
-      const dtsRes = iconRowTemplate(icon, name, iconData, "dts");
+      const dtsRes = iconRowTemplate(icon, name, iconData, "dts", reExport);
       await fs.appendFile(
         path.resolve(DIST, icon.id, "index.d.ts"),
         dtsRes,

--- a/packages/react-icons/scripts/templates.ts
+++ b/packages/react-icons/scripts/templates.ts
@@ -19,9 +19,7 @@ export const iconRowTemplate: IconRowTemplateFunction = (
   switch (type) {
     case "module":
       if (reExport) {
-        return (
-          `export * from './${formattedName}';\n`
-        );
+        return `export * from './${formattedName}';\n`;
       }
       return (
         `export function ${formattedName} (props) {\n` +
@@ -45,4 +43,4 @@ export const iconRowTemplate: IconRowTemplateFunction = (
     default:
       throw new Error(`Unknown type: ${type}`);
   }
-}
+};

--- a/packages/react-icons/scripts/templates.ts
+++ b/packages/react-icons/scripts/templates.ts
@@ -1,20 +1,40 @@
 import type { IconTree } from "src";
 import type { IconDefinition } from "./_types";
 
-export function iconRowTemplate(
+export type IconRowTemplateFunction = (
   icon: IconDefinition,
   formattedName: string,
   iconData: IconTree,
+  type: "module" | "common" | "dts",
+  reExport?: boolean,
+) => string;
+
+export const iconRowTemplate: IconRowTemplateFunction = (
+  icon,
+  formattedName,
+  iconData,
   type = "module",
-) {
+  reExport,
+) => {
   switch (type) {
     case "module":
+      if (reExport) {
+        return (
+          `export * from './${formattedName}';\n`
+        );
+      }
       return (
         `export function ${formattedName} (props) {\n` +
         `  return GenIcon(${JSON.stringify(iconData)})(props);\n` +
         `};\n`
       );
     case "common":
+      if (reExport) {
+        return (
+          `const ${formattedName} = require('./${formattedName}');\n` +
+          `module.exports.${formattedName} = ${formattedName};\n`
+        );
+      }
       return (
         `module.exports.${formattedName} = function ${formattedName} (props) {\n` +
         `  return GenIcon(${JSON.stringify(iconData)})(props);\n` +


### PR DESCRIPTION
Hello everyone, first of all, I need to say thanks for that project. It's has a lot of amazing assets 🚀 

In that PR, I`m spliting the files of react-icons/all. 
The idea is to allow use tree shaking by building tools like babel.

In the build bundle, the files was splitted and still can be used by direct import in index files:

![image](https://github.com/user-attachments/assets/d7b2d3bd-f36b-48f6-a23f-a67a4c111a34)

If there are any questions, please ask.
Thank you in advance for your attention

