### PR TITLE
feat: Add Maki icons

### DIFF
--- a/packages/_react-icons_all-files/package.json
+++ b/packages/_react-icons_all-files/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-icons/all-files",
-  "version": "5.2.1",
+  "version": "5.3.0",
   "description": "SVG React icons of popular icon packs using ES6 imports",
   "author": "Goran Gajic",
   "contributors": [

--- a/packages/_react-icons_all/package.json
+++ b/packages/_react-icons_all/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-icons",
-  "version": "5.2.1",
+  "version": "5.3.0",
   "description": "SVG React icons of popular icon packs using ES6 imports",
   "author": "Goran Gajic",
   "contributors": [
@@ -220,6 +220,12 @@
       "require": "./lia/index.js",
       "import": "./lia/index.mjs",
       "default": "./lia/index.mjs"
+    },
+    "./mk": {
+      "types": "./mk/index.d.ts",
+      "require": "./mk/index.js",
+      "import": "./mk/index.mjs",
+      "default": "./mk/index.mjs"
     }
   }
 }

--- a/packages/react-icons/VERSIONS
+++ b/packages/react-icons/VERSIONS
@@ -9,7 +9,7 @@
 | [Typicons](http://s-ings.com/typicons/) | [CC BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/) | 2.1.2 | 336 |
 | [Github Octicons icons](https://octicons.github.com/) | [MIT](https://github.com/primer/octicons/blob/master/LICENSE) | 18.3.0 | 264 |
 | [Feather](https://feathericons.com/) | [MIT](https://github.com/feathericons/feather/blob/master/LICENSE) | 4.29.1 | 287 |
-| [Lucide](https://lucide.dev/) | [ISC](https://github.com/lucide-icons/lucide/blob/main/LICENSE) | v5.2.1-3-g03c80d93 | 1215 |
+| [Lucide](https://lucide.dev/) | [ISC](https://github.com/lucide-icons/lucide/blob/main/LICENSE) | v5.3.0-7-gec03540a | 1215 |
 | [Game Icons](https://game-icons.net/) | [CC BY 3.0](https://creativecommons.org/licenses/by/3.0/) | 12920d6565588f0512542a3cb0cdfd36a497f910 | 4040 |
 | [Weather Icons](https://erikflowers.github.io/weather-icons/) | [SIL OFL 1.1](http://scripts.sil.org/OFL) | 2.0.12 | 219 |
 | [Devicons](https://vorillaz.github.io/devicons/) | [MIT](https://opensource.org/licenses/MIT) | 1.8.0 | 192 |
@@ -31,3 +31,4 @@
 | [Radix Icons](https://icons.radix-ui.com) | [MIT](https://github.com/radix-ui/icons/blob/master/LICENSE) | @radix-ui/react-icons@1.3.0-1-g94b3fcf | 318 |
 | [Phosphor Icons](https://github.com/phosphor-icons/core) | [MIT](https://github.com/phosphor-icons/core/blob/main/LICENSE) | 2.1.1 | 9072 |
 | [Icons8 Line Awesome](https://icons8.com/line-awesome) | [MIT](https://github.com/icons8/line-awesome/blob/master/LICENSE.md) | 1.3.1 | 1544 |
+| [Maki Icons](https://labs.mapbox.com/maki-icons/) | [CC0 1.0 Universal](https://github.com/mapbox/maki/blob/main/LICENSE.txt) | 8.0.1 | 213 |

--- a/packages/react-icons/src/icons/index.ts
+++ b/packages/react-icons/src/icons/index.ts
@@ -647,7 +647,7 @@ export const icons: IconDefinition[] = [
       localName: "css.gg",
       remoteDir: "icons/svg/",
       url: "https://github.com/astrit/css.gg.git",
-      branch: "master",
+      branch: "main",
       hash: "deea4fa5f39a2980d7586aed18d65cdba6fd85e3",
     },
   },
@@ -795,6 +795,27 @@ export const icons: IconDefinition[] = [
       url: "https://github.com/icons8/line-awesome.git",
       branch: "master",
       hash: "78a101217707c9b1c4dcf2a821be75684e36307f",
+    },
+  },
+  {
+    id: "mk",
+    name: "Maki Icons",
+    contents: [
+      {
+        files: path.resolve(__dirname, "../../icons/maki/icons/*.svg"),
+        formatter: (name) => `Mk${name}`,
+      },
+    ],
+    projectUrl: "https://labs.mapbox.com/maki-icons/",
+    license: "CC0 1.0 Universal",
+    licenseUrl: "https://github.com/mapbox/maki/blob/main/LICENSE.txt",
+    source: {
+      type: "git",
+      localName: "maki",
+      remoteDir: "icons/",
+      url: "https://github.com/mapbox/maki.git",
+      branch: "main",
+      hash: "7e8795288b529c3570230cde0a32bd40c0c284b8",
     },
   },
 ];


### PR DESCRIPTION
Adds Mapbox's Maki icon set:

> Maki is an icon set made for map designers. Maki includes icons for common points of interest like parks, museums, and places of worship. Each icon is available as a 15px by 15px SVG file. Maki is open source and [CC0 licensed](https://creativecommons.org/publicdomain/zero/1.0/).

Consists of 213 icons:

<img width="1095" alt="Screenshot 2024-09-30 at 6 31 23 PM" src="https://github.com/user-attachments/assets/99436a8e-3d72-4a9e-bc0c-5e16e3ce6db6">

Also updates the branch name for css.gg because it appears they switched from `master` to `main` and I wasn't able to build without updating. 