### PR TITLE
Feat: Change feather icons integration approach

### DIFF
--- a/packages/_react-icons_all-files/package.json
+++ b/packages/_react-icons_all-files/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-icons/all-files",
-  "version": "5.2.1",
+  "version": "5.3.0",
   "description": "SVG React icons of popular icon packs using ES6 imports",
   "author": "Goran Gajic",
   "contributors": [

--- a/packages/_react-icons_all/package.json
+++ b/packages/_react-icons_all/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-icons",
-  "version": "5.2.1",
+  "version": "5.3.0",
   "description": "SVG React icons of popular icon packs using ES6 imports",
   "author": "Goran Gajic",
   "contributors": [

--- a/packages/demo/src/App.js
+++ b/packages/demo/src/App.js
@@ -9,6 +9,7 @@ import { TiArrowDown } from "react-icons/ti";
 import { GrGrommet } from "react-icons/gr";
 import { LiaNode } from "react-icons/lia";
 import { TbPentagonNumber0 } from "react-icons/tb";
+import { FiTable } from "react-icons/fi";
 
 class App extends Component {
   render() {
@@ -40,6 +41,7 @@ class App extends Component {
           <GrGrommet />
           <LiaNode />
           <TbPentagonNumber0 />
+          <FiTable />
         </p>
       </div>
     );

--- a/packages/demo/src/__snapshots__/App.test.js.snap
+++ b/packages/demo/src/__snapshots__/App.test.js.snap
@@ -52,6 +52,7 @@ exports[`snapshot test 1`] = `
     <GrGrommet />
     <LiaNode />
     <TbPentagonNumber0 />
+    <FiTable />
   </p>
 </div>
 `;

--- a/packages/react-icons/VERSIONS
+++ b/packages/react-icons/VERSIONS
@@ -8,8 +8,8 @@
 | [Material Design icons](http://google.github.io/material-design-icons/) | [Apache License Version 2.0](https://github.com/google/material-design-icons/blob/master/LICENSE) | 4.0.0-98-g9beae745bb | 4341 |
 | [Typicons](http://s-ings.com/typicons/) | [CC BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/) | 2.1.2 | 336 |
 | [Github Octicons icons](https://octicons.github.com/) | [MIT](https://github.com/primer/octicons/blob/master/LICENSE) | 18.3.0 | 264 |
-| [Feather](https://feathericons.com/) | [MIT](https://github.com/feathericons/feather/blob/master/LICENSE) | 4.29.1 | 287 |
-| [Lucide](https://lucide.dev/) | [ISC](https://github.com/lucide-icons/lucide/blob/main/LICENSE) | v5.2.1-3-g03c80d93 | 1215 |
+| [Feather](https://feathericons.com/) | [MIT](https://github.com/feathericons/feather/blob/master/LICENSE) | 4.29.2 | 287 |
+| [Lucide](https://lucide.dev/) | [ISC](https://github.com/lucide-icons/lucide/blob/main/LICENSE) | ec03540a3e6feb18bd9c84a9c53a0b15a6a73deb | 1215 |
 | [Game Icons](https://game-icons.net/) | [CC BY 3.0](https://creativecommons.org/licenses/by/3.0/) | 12920d6565588f0512542a3cb0cdfd36a497f910 | 4040 |
 | [Weather Icons](https://erikflowers.github.io/weather-icons/) | [SIL OFL 1.1](http://scripts.sil.org/OFL) | 2.0.12 | 219 |
 | [Devicons](https://vorillaz.github.io/devicons/) | [MIT](https://opensource.org/licenses/MIT) | 1.8.0 | 192 |

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -37,7 +37,6 @@
     "cheerio": "^1.0.0-rc.12",
     "esbuild": "^0.20.2",
     "esbuild-register": "^3.5.0",
-    "feather-icons": "^4.7.3",
     "find-package": "^1.0.0",
     "glob": "^8.1.0",
     "glob-promise": "^6.0.5",

--- a/packages/react-icons/src/icons/index.ts
+++ b/packages/react-icons/src/icons/index.ts
@@ -222,16 +222,21 @@ export const icons: IconDefinition[] = [
     name: "Feather",
     contents: [
       {
-        files: path.resolve(
-          path.dirname(require.resolve("feather-icons")),
-          "icons/*.svg",
-        ),
+        files: path.resolve(__dirname, "../../icons/feather/icons/*.svg"),
         formatter: (name) => `Fi${name}`,
       },
     ],
     projectUrl: "https://feathericons.com/",
     license: "MIT",
     licenseUrl: "https://github.com/feathericons/feather/blob/master/LICENSE",
+    source: {
+      type: "git",
+      localName: "feather",
+      remoteDir: "icons/",
+      url: "https://github.com/feathericons/feather.git",
+      branch: "main",
+      hash: "1b002399e8758fb2bccea4d07312dc9e0f43dcb8",
+    },
   },
   {
     id: "lu",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8094,13 +8094,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"classnames@npm:^2.2.5":
-  version: 2.3.2
-  resolution: "classnames@npm:2.3.2"
-  checksum: 2c62199789618d95545c872787137262e741f9db13328e216b093eea91c85ef2bfb152c1f9e63027204e2559a006a92eb74147d46c800a9f96297ae1d9f96f4e
-  languageName: node
-  linkType: hard
-
 "clean-css@npm:^5.2.2":
   version: 5.3.2
   resolution: "clean-css@npm:5.3.2"
@@ -8655,7 +8648,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"core-js@npm:^3.1.3, core-js@npm:^3.19.2":
+"core-js@npm:^3.19.2":
   version: 3.33.2
   resolution: "core-js@npm:3.33.2"
   checksum: 71de081acbd060ff985afdcdf2552de4a00ab3ac4695c77f3535b72ddf4526920dcd0cb73e72e57c2ae16e384838a6d55790e138f0a19d60afcf851f89d0064d
@@ -11072,16 +11065,6 @@ __metadata:
   dependencies:
     bser: 2.1.1
   checksum: b15a124cef28916fe07b400eb87cbc73ca082c142abf7ca8e8de6af43eca79ca7bd13eb4d4d48240b3bd3136eaac40d16e42d6edf87a8e5d1dd8070626860c78
-  languageName: node
-  linkType: hard
-
-"feather-icons@npm:^4.7.3":
-  version: 4.29.1
-  resolution: "feather-icons@npm:4.29.1"
-  dependencies:
-    classnames: ^2.2.5
-    core-js: ^3.1.3
-  checksum: 87c7d1b2a5049e0be1dbae27bd5d287c5abd9f4d6bc81783fa8559b2946fbd1e885f658584d0cff1879cb7bdedafaeb68e7548e2d5fcde40b9fcc74368259b92
   languageName: node
   linkType: hard
 
@@ -18620,7 +18603,6 @@ __metadata:
     cheerio: ^1.0.0-rc.12
     esbuild: ^0.20.2
     esbuild-register: ^3.5.0
-    feather-icons: ^4.7.3
     find-package: ^1.0.0
     glob: ^8.1.0
     glob-promise: ^6.0.5


### PR DESCRIPTION
Change feather icons integration approach from node_module to git integration

This implementation was done for https://github.com/react-icons/react-icons/issues/556