### PR TITLE
Fix: Issue #986 - Handled empty whitespaces in the beginning

### DIFF
--- a/packages/_react-icons_all-files/package.json
+++ b/packages/_react-icons_all-files/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-icons/all-files",
-  "version": "5.2.1",
+  "version": "5.3.0",
   "description": "SVG React icons of popular icon packs using ES6 imports",
   "author": "Goran Gajic",
   "contributors": [

--- a/packages/_react-icons_all/package.json
+++ b/packages/_react-icons_all/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-icons",
-  "version": "5.2.1",
+  "version": "5.3.0",
   "description": "SVG React icons of popular icon packs using ES6 imports",
   "author": "Goran Gajic",
   "contributors": [

--- a/packages/preview-astro/src/components/searchinput.tsx
+++ b/packages/preview-astro/src/components/searchinput.tsx
@@ -18,8 +18,16 @@ export function SearchInput() {
   const [inputQuery, setInputQuery] = React.useState("");
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const query = e.target.value;
+
+    if (query.trim() === '' || query.startsWith(' ')) {
+      setInputQuery('');
+      debouncedOnSearch('');
+      return;
+    }
+
     setInputQuery(query);
-    debouncedOnSearch(query);
+
+    debouncedOnSearch(query.trim());
   };
   return (
     <input

--- a/packages/preview-astro/src/components/searchinput.tsx
+++ b/packages/preview-astro/src/components/searchinput.tsx
@@ -26,7 +26,6 @@ export function SearchInput() {
     }
 
     setInputQuery(query);
-
     debouncedOnSearch(query.trim());
   };
   return (

--- a/packages/react-icons/VERSIONS
+++ b/packages/react-icons/VERSIONS
@@ -9,7 +9,7 @@
 | [Typicons](http://s-ings.com/typicons/) | [CC BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/) | 2.1.2 | 336 |
 | [Github Octicons icons](https://octicons.github.com/) | [MIT](https://github.com/primer/octicons/blob/master/LICENSE) | 18.3.0 | 264 |
 | [Feather](https://feathericons.com/) | [MIT](https://github.com/feathericons/feather/blob/master/LICENSE) | 4.29.1 | 287 |
-| [Lucide](https://lucide.dev/) | [ISC](https://github.com/lucide-icons/lucide/blob/main/LICENSE) | v5.2.1-3-g03c80d93 | 1215 |
+| [Lucide](https://lucide.dev/) | [ISC](https://github.com/lucide-icons/lucide/blob/main/LICENSE) | ec03540a3e6feb18bd9c84a9c53a0b15a6a73deb | 1215 |
 | [Game Icons](https://game-icons.net/) | [CC BY 3.0](https://creativecommons.org/licenses/by/3.0/) | 12920d6565588f0512542a3cb0cdfd36a497f910 | 4040 |
 | [Weather Icons](https://erikflowers.github.io/weather-icons/) | [SIL OFL 1.1](http://scripts.sil.org/OFL) | 2.0.12 | 219 |
 | [Devicons](https://vorillaz.github.io/devicons/) | [MIT](https://opensource.org/licenses/MIT) | 1.8.0 | 192 |


### PR DESCRIPTION
This pull request addresses **[issue #986](https://github.com/react-icons/react-icons/issues/986)**, where leading whitespace in input queries led to unexpected behavior in the search functionality.

- The root cause was the system's inability to handle leading spaces correctly in the search input.
- I have updated the logic to trim any leading spaces and ensured that the search is not triggered when the input begins with empty whitespace.

### Testing:
- Conducted manual tests by entering queries that included leading spaces, spaces between words, and using backspace to clear input.
- Verified that spaces between words are retained, while leading spaces do not initiate a search.

### Additional Notes:
- This fix is backward-compatible and does not introduce any breaking changes.
