### PR TITLE
preview: Reduce the number of results displayed in search results

### DIFF
--- a/packages/preview-astro/src/components/search/search-iconset.tsx
+++ b/packages/preview-astro/src/components/search/search-iconset.tsx
@@ -30,13 +30,18 @@ export function SearchIconSet({
 
   const found =
     icons &&
-    Object.keys(icons).filter((name) =>
-      query
-        .toLowerCase()
-        .split(" ")
-        .filter((t) => !!t)
-        .every((term) => name.toLowerCase().includes(term)),
-    );
+    Object.keys(icons)
+      .filter((name) => {
+        const rules = query
+          .toLowerCase()
+          .split(" ")
+          .filter((t) => !!t);
+        return rules.length == 0
+          ? false
+          : rules.every((term) => name.toLowerCase().includes(term));
+      })
+      .slice(0, 100); // show top 100 icons
+
   return (
     <>
       {found ? (


### PR DESCRIPTION
- close #986 
- If there are two consecutive spaces, all items match. In this case, nothing should be displayed.
- If the number of items to be displayed is large, the browser may take a long time to load. Only 100 items will be displayed for each icon set.
