### PR TITLE
[React 19] Update IconType type to return React.ReactNode

### DIFF
--- a/packages/react-icons/src/iconBase.tsx
+++ b/packages/react-icons/src/iconBase.tsx
@@ -35,7 +35,7 @@ export interface IconBaseProps extends React.SVGAttributes<SVGElement> {
   title?: string;
 }
 
-export type IconType = (props: IconBaseProps) => JSX.Element;
+export type IconType = (props: IconBaseProps) => React.ReactNode;
 export function IconBase(
   props: IconBaseProps & { attr?: Record<string, string> },
 ): JSX.Element {


### PR DESCRIPTION
React 19 requires ReactNode type as component output to remove linting errors in Typescript, end results are the same.