### PR TITLE
Added more control over the icons / added gradient colors  

### DIFF
--- a/packages/react-icons/src/iconBase.tsx
+++ b/packages/react-icons/src/iconBase.tsx
@@ -58,6 +58,31 @@ export interface IconBaseProps extends React.SVGAttributes<SVGElement> {
   size?: string | number;
   color?: string;
   title?: string;
+  iconDataOverride?: Partial<IconTree>[];
+  stops: React.SVGProps<SVGStopElement>[],
+  startCoordinates?: StartCoordinates;
+}
+
+interface StartCoordinates {
+  top?: number,
+  right?: number,
+  down?: number,
+  left?: number,
+}
+
+export interface GradientBaseProps {
+  stops: React.SVGProps<SVGStopElement>[],
+  startCoordinates?: StartCoordinates;
+}
+function renderGradient({ stops, startCoordinates = {} }: GradientBaseProps): JSX.Element {
+  const { top = 0, right = 100, down = 0, left = 0 } = startCoordinates;
+  return (
+    <linearGradient id="reactIconsGradient" x1={`${left}%`} x2={`${right}%`} y1={`${top}%`} y2={`${down}%`}>
+      {stops.map((stopProp, index) => (
+        <stop key={index} {...stopProp} />
+      ))}
+    </linearGradient>
+  );
 }
 
 export type IconType = (props: IconBaseProps) => React.ReactNode;
@@ -65,7 +90,13 @@ export function IconBase(
   props: IconBaseProps & { attr?: Record<string, string> },
 ): JSX.Element {
   const elem = (conf: IconContext) => {
-    const { attr, size, title, ...svgProps } = props;
+    const {
+      attr,
+      size,
+      title,
+      stops,
+      startCoordinates = { top: 0, right: 100, down: 0, left: 0 },
+      ...svgProps } = props;
     const computedSize = size || conf.size || "1em";
     let className;
     if (conf.className) className = conf.className;
@@ -92,6 +123,7 @@ export function IconBase(
       >
         {title && <title>{title}</title>}
         {props.children}
+        {stops && renderGradient({ stops, startCoordinates })}
       </svg>
     );
   };

--- a/packages/react-icons/src/iconBase.tsx
+++ b/packages/react-icons/src/iconBase.tsx
@@ -42,11 +42,15 @@ function Tree2Element(tree: IconTree[], iconDataOverride: Partial<IconTree>[] = 
 }
 
 export function GenIcon(data: IconTree) {
-  return (props: IconBaseProps) => (
-    <IconBase attr={{ ...data.attr }} {...props}>
-      {Tree2Element(data.child)}
-    </IconBase>
-  );
+  return (props: IconBaseProps) => {
+    const { iconDataOverride, ...restProps } = props;
+
+    return (
+      <IconBase attr={{ ...data.attr }} {...restProps}>
+        {Tree2Element(data.child, iconDataOverride, !!props.stops)}
+      </IconBase>
+    )
+  }
 }
 
 export interface IconBaseProps extends React.SVGAttributes<SVGElement> {

--- a/packages/react-icons/src/iconBase.tsx
+++ b/packages/react-icons/src/iconBase.tsx
@@ -8,18 +8,39 @@ export interface IconTree {
   child: IconTree[];
 }
 
-function Tree2Element(tree: IconTree[]): React.ReactElement[] {
-  return (
-    tree &&
-    tree.map((node, i) =>
-      React.createElement(
-        node.tag,
-        { key: i, ...node.attr },
-        Tree2Element(node.child),
-      ),
-    )
-  );
+function Tree2Element(tree: IconTree[], iconDataOverride: Partial<IconTree>[] = [], userGradient: boolean = false): React.ReactElement[] {
+  const res: React.ReactElement[] = [];
+
+  if (tree) {
+    const maxLength = Math.max(tree.length, iconDataOverride?.length || 0);
+
+    for (let i = 0; i < maxLength; i++) {
+      const node = tree[i];
+      const overrideNode = iconDataOverride?.[i];
+
+      if (overrideNode) {
+        res.push(
+          React.createElement(
+            overrideNode.tag || node.tag,
+            { key: i, ...node?.attr, ...overrideNode?.attr, ...(userGradient ? { fill: "url(#reactIconsGradient)" } : {}) },
+            Tree2Element(node?.child, overrideNode?.child, userGradient)
+          )
+        );
+      } else if (node) {
+        res.push(
+          React.createElement(
+            node.tag,
+            { key: i, ...node?.attr, ...(userGradient ? { fill: "url(#reactIconsGradient)" } : {}) },
+            Tree2Element(node?.child, [], userGradient)
+          )
+        );
+      }
+    }
+  }
+
+  return res;
 }
+
 export function GenIcon(data: IconTree) {
   return (props: IconBaseProps) => (
     <IconBase attr={{ ...data.attr }} {...props}>


### PR DESCRIPTION
Hello :)
i had same as this problem https://github.com/react-icons/react-icons/issues/251
i wanted to use gradient. so i hade to make solution.

new features:

1. Ability to change/add children of the svg
2. Added gradient option by adding array of stops object as prop.

now will have icons like:
![image](https://github.com/user-attachments/assets/c2537758-3029-4604-928d-b55bf166cca4)
![image](https://github.com/user-attachments/assets/8bfdda6c-a292-460a-9aeb-60aaed2205aa)

hope this will merge 
if you want any changes in the code that added feel free to guide me :) .
Have Great day.

