### PR TITLE
Add Hugeicons icon pack with 4497 icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ function Question() {
 | [Radix Icons](https://icons.radix-ui.com)                               | [MIT](https://github.com/radix-ui/icons/blob/master/LICENSE)                                      | @radix-ui/react-icons@1.3.0-1-g94b3fcf   |   318 |
 | [Phosphor Icons](https://github.com/phosphor-icons/core)                | [MIT](https://github.com/phosphor-icons/core/blob/main/LICENSE)                                   | 2.1.1                                    |  9072 |
 | [Icons8 Line Awesome](https://icons8.com/line-awesome)                  | [MIT](https://github.com/icons8/line-awesome/blob/master/LICENSE.md)                              | 1.3.1                                    |  1544 |
+| [Hugeicons](https://hugeicons.com)                                      | [MIT](https://opensource.org/licenses/MIT)                                                        | 0.1.5                                    |  4497 |
 
 You can add more icons by submitting pull requests or creating issues.
 

--- a/packages/_react-icons_all/package.json
+++ b/packages/_react-icons_all/package.json
@@ -155,6 +155,12 @@
       "import": "./hi2/index.mjs",
       "default": "./hi2/index.mjs"
     },
+    "./hgi": {
+      "types": "./hgi/index.d.ts",
+      "require": "./hgi/index.js",
+      "import": "./hgi/index.mjs",
+      "default": "./hgi/index.mjs"
+    },
     "./si": {
       "types": "./si/index.d.ts",
       "require": "./si/index.js",

--- a/packages/react-icons/VERSIONS
+++ b/packages/react-icons/VERSIONS
@@ -20,6 +20,7 @@
 | [Grommet-Icons](https://github.com/grommet/grommet-icons) | [Apache License Version 2.0](http://www.apache.org/licenses/) | 4.12.1 | 635 |
 | [Heroicons](https://github.com/tailwindlabs/heroicons) | [MIT](https://opensource.org/licenses/MIT) | 1.0.6 | 460 |
 | [Heroicons 2](https://github.com/tailwindlabs/heroicons) | [MIT](https://opensource.org/licenses/MIT) | 2.2.0 | 972 |
+| [Hugeicons](https://hugeicons.com) | [MIT](https://opensource.org/licenses/MIT) | 0.1.5 | 4497 |
 | [Simple Icons](https://simpleicons.org/) | [CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/) | 13.19.0 | 3275 |
 | [Simple Line Icons](https://thesabbir.github.io/simple-line-icons/) | [MIT](https://opensource.org/licenses/MIT) | 2.5.5 | 189 |
 | [IcoMoon Free](https://github.com/Keyamoon/IcoMoon-Free) | [CC BY 4.0 License](https://github.com/Keyamoon/IcoMoon-Free/blob/master/License.txt) | d006795ede82361e1bac1ee76f215cf1dc51e4ca | 491 |

--- a/packages/react-icons/src/icons/index.ts
+++ b/packages/react-icons/src/icons/index.ts
@@ -532,7 +532,7 @@ export const icons: IconDefinition[] = [
     },
   },
   {
-    id: 'hgi',
+    id: "hgi",
     name: "Hugeicons",
     contents: [
       {

--- a/packages/react-icons/src/icons/index.ts
+++ b/packages/react-icons/src/icons/index.ts
@@ -532,6 +532,27 @@ export const icons: IconDefinition[] = [
     },
   },
   {
+    id: 'hgi',
+    name: "Hugeicons",
+    contents: [
+      {
+        files: path.resolve(__dirname, "../../icons/hugeicons/icons/*.svg"),
+        formatter: (name) => `Hgi${name}`,
+      },
+    ],
+    projectUrl: "https://hugeicons.com",
+    license: "MIT",
+    licenseUrl: "https://opensource.org/licenses/MIT",
+    source: {
+      type: "git",
+      localName: "hugeicons",
+      remoteDir: "icons/",
+      url: "https://github.com/hugeicons/hugeicons-static.git",
+      branch: "master",
+      hash: "f9dbcca8d72cc2777a0ccd873c274d9bf7a153e6",
+    },
+  },
+  {
     id: "si",
     name: "Simple Icons",
     contents: [


### PR DESCRIPTION
## Summary                                                                                                                                       

Adds [Hugeicons](https://hugeicons.com) icon set (4,497 stroke-rounded SVG icons) to react-icons under the `hgi` prefix.

- **Source:** [hugeicons/hugeicons-static](https://github.com/hugeicons/hugeicons-static) @ `f9dbcca`
- **License:** MIT (declared in `package.json`)
- **Prefix:** `hgi` — e.g. `import { HgiHome } from 'react-icons/hgi'`
- **Icon count:** 4,497
- **Style:** Stroke-rounded

Hugeicons is an open-source icon library with framework packages for [React](https://github.com/hugeicons/react),
[Vue](https://github.com/hugeicons/vue), [Svelte](https://github.com/hugeicons/svelte), [Angular](https://github.com/hugeicons/angular), and [React
 Native](https://github.com/hugeicons/react-native).

### Changes

- `packages/react-icons/src/icons/index.ts` — added Hugeicons icon definition
- `README.md` — added Hugeicons row to the icon set table
- `packages/react-icons/VERSIONS` — added version entry
- `packages/_react-icons_all/package.json` — added `./hgi` export