### PR TITLE
update tabler icons hash

### DIFF
--- a/packages/react-icons/src/icons/index.ts
+++ b/packages/react-icons/src/icons/index.ts
@@ -1,5 +1,5 @@
-import camelcase from "camelcase";
 import path from "path";
+import camelcase from "camelcase";
 import { type IconDefinition } from "../../scripts/_types";
 import { glob } from "../../scripts/glob";
 
@@ -703,7 +703,7 @@ export const icons: IconDefinition[] = [
       remoteDir: "icons/",
       url: "https://github.com/tabler/tabler-icons.git",
       branch: "main",
-      hash: "147130cd0e67a9cfc70538f8b3a14a48a695d90b",
+      hash: "01eb08a9bc8075f5bd6828ac30b0a3a038a9ef46",
     },
   },
   {

--- a/packages/react-icons/src/icons/index.ts
+++ b/packages/react-icons/src/icons/index.ts
@@ -1,5 +1,5 @@
-import path from "path";
 import camelcase from "camelcase";
+import path from "path";
 import { type IconDefinition } from "../../scripts/_types";
 import { glob } from "../../scripts/glob";
 
@@ -703,7 +703,7 @@ export const icons: IconDefinition[] = [
       remoteDir: "icons/",
       url: "https://github.com/tabler/tabler-icons.git",
       branch: "main",
-      hash: "01eb08a9bc8075f5bd6828ac30b0a3a038a9ef46",
+      hash: "147130cd0e67a9cfc70538f8b3a14a48a695d90b",
     },
   },
   {


### PR DESCRIPTION
This PR updates the Tabler Icons source hash to the latest commit on the main branch of https://github.com/tabler/tabler-icons

Changes:
Updated tabler icon hash

Proposed Feature:
Use a git submodule architecture to prevent manual hash updates

Resolves #1076 