### PR TITLE
fix: Scroll to top when search on demo site

### DIFF
--- a/packages/preview-astro/src/utils/usesearch.tsx
+++ b/packages/preview-astro/src/utils/usesearch.tsx
@@ -25,6 +25,7 @@ export function useSearch(): UseSearchValue {
         ? "replace"
         : "push";
     navigate(`/react-icons/search/#q=${query}`, { history });
+    window.scrollTo({ top: 0, behavior: "smooth" });
     searchWord.set(query);
   }, []);
 


### PR DESCRIPTION
Closes #1084 

Scroll to the top when search text change on the demo site
